### PR TITLE
Fix probation-record to call correct endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ cypress/
 integration-tests/videos/
 integration-tests/integration/examples/
 integration-tests/screenshots/
+.vscode/settings.json
+.vscode/launch.json

--- a/mappings/community/D541487-convictions.json
+++ b/mappings/community/D541487-convictions.json
@@ -2,7 +2,7 @@
   "id": "716da826-d614-42dd-9c06-6a639c318797",
   "request": {
     "method": "GET",
-    "urlPathPattern": "/offender/D541487/convictions"
+    "urlPathPattern": "/offender/D541487/probation-record"
   },
   "response": {
     "headers": {

--- a/mappings/community/D814575-convictions.json
+++ b/mappings/community/D814575-convictions.json
@@ -2,7 +2,7 @@
   "id": "4e81d50a-23b2-45d2-a86f-19a68346a193",
   "request": {
     "method": "GET",
-    "urlPathPattern": "/offender/D814575/convictions"
+    "urlPathPattern": "/offender/D814575/probation-record"
   },
   "response": {
     "headers": {

--- a/mappings/community/D985513-convictions.json
+++ b/mappings/community/D985513-convictions.json
@@ -2,7 +2,7 @@
   "id": "695b4a38-8826-465b-b0ee-6bf5ec536c87",
   "request": {
     "method": "GET",
-    "urlPathPattern": "/offender/D985513/convictions"
+    "urlPathPattern": "/offender/D985513/probation-record"
   },
   "response": {
     "headers": {

--- a/mappings/community/D991494-convictions.json
+++ b/mappings/community/D991494-convictions.json
@@ -2,7 +2,7 @@
   "id": "8de5d670-bf88-41d5-bda1-56485a41551b",
   "request": {
     "method": "GET",
-    "urlPathPattern": "/offender/D991494/convictions"
+    "urlPathPattern": "/offender/D991494/probation-record"
   },
   "response": {
     "headers": {

--- a/mappings/community/DX12340A-convictions.json
+++ b/mappings/community/DX12340A-convictions.json
@@ -2,7 +2,7 @@
   "id": "6b578453-8e26-4512-a610-347159e2126a",
   "request": {
     "method": "GET",
-    "urlPathPattern": "/offender/DX12340A/convictions"
+    "urlPathPattern": "/offender/DX12340A/probation-record"
   },
   "response": {
     "headers": {

--- a/routes/view.js
+++ b/routes/view.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const moment = require('moment')
 const { getCaseList, getCase } = require('../services/case-service')
-const { getPersonalDetails, getConvictions, getAttendanceDetails } = require('../services/community-service')
+const { getPersonalDetails, getProbationRecord, getAttendanceDetails } = require('../services/community-service')
 const router = express.Router()
 
 const { health } = require('./middleware/healthcheck')
@@ -69,7 +69,7 @@ router.get('/case/:caseNo/:section?/:detail?', health, defaults, async (req, res
       templateValues.title = params.detail ? 'Order details' : 'Probation record'
       template = !params.detail ? 'case-summary-record' : 'case-summary-record-attendance'
       if (response && response.crn) {
-        communityResponse = await getConvictions(response.crn)
+        communityResponse = await getProbationRecord(response.crn)
         if (!params.detail) {
           const personalDetails = await getPersonalDetails(response.crn)
           communityResponse = {

--- a/services/community-service.js
+++ b/services/community-service.js
@@ -6,8 +6,9 @@ const getPersonalDetails = async crn => {
   return res.data
 }
 
-const getConvictions = async crn => {
-  const res = await request(`${apiUrl}/offender/${crn}/convictions`)
+const getProbationRecord = async crn => {
+  console.log(`Now calling for probation-record: ${apiUrl}/offender/${crn}/probation-record`)
+  const res = await request(`${apiUrl}/offender/${crn}/probation-record`)
   return res.data
 }
 
@@ -18,6 +19,6 @@ const getAttendanceDetails = async (crn, orderId) => {
 
 module.exports = {
   getPersonalDetails,
-  getConvictions,
+  getProbationRecord: getProbationRecord,
   getAttendanceDetails
 }

--- a/tests/routes/view.test.js
+++ b/tests/routes/view.test.js
@@ -37,7 +37,7 @@ describe('Routes', () => {
     return {}
   })
 
-  jest.spyOn(communityService, 'getConvictions').mockImplementation(function () {
+  jest.spyOn(communityService, 'getProbationRecord').mockImplementation(function () {
     return {}
   })
 
@@ -111,7 +111,7 @@ describe('Routes', () => {
     }
     const response = await request(app).get('/case/8678951874/record')
     expect(caseService.getCase).toHaveBeenCalledWith('SHF', '8678951874')
-    expect(communityService.getConvictions).toHaveBeenCalledWith('D985513')
+    expect(communityService.getProbationRecord).toHaveBeenCalledWith('D985513')
     expect(communityService.getPersonalDetails).toHaveBeenCalledWith('D985513')
     return response
   })
@@ -123,7 +123,7 @@ describe('Routes', () => {
     }
     const response = await request(app).get('/case/668911253/record/1403337513')
     expect(caseService.getCase).toHaveBeenCalledWith('SHF', '668911253')
-    expect(communityService.getConvictions).toHaveBeenCalledWith('D985513')
+    expect(communityService.getProbationRecord).toHaveBeenCalledWith('D985513')
     expect(communityService.getAttendanceDetails).toHaveBeenCalledWith('D985513', '1403337513')
     return response
   })

--- a/tests/services/community-service.test.js
+++ b/tests/services/community-service.test.js
@@ -2,7 +2,7 @@
 const moxios = require('moxios')
 const { apiUrl } = require('../../config/defaults')
 
-const { getPersonalDetails, getConvictions, getAttendanceDetails } = require('../../services/community-service')
+const { getPersonalDetails, getProbationRecord, getAttendanceDetails } = require('../../services/community-service')
 
 describe('Community service', () => {
   beforeEach(() => {
@@ -28,15 +28,15 @@ describe('Community service', () => {
   })
 
   it('should call the API to request offender conviction details data', async () => {
-    moxios.stubRequest(`${apiUrl}/offender/D123456/convictions`, {
+    moxios.stubRequest(`${apiUrl}/offender/D123456/probation-record`, {
       status: 200,
       response: {
         data: {}
       }
     })
 
-    const response = await getConvictions('D123456')
-    expect(moxios.requests.mostRecent().url).toBe(`${apiUrl}/offender/D123456/convictions`)
+    const response = await getProbationRecord('D123456')
+    expect(moxios.requests.mostRecent().url).toBe(`${apiUrl}/offender/D123456/probation-record`)
     return response
   })
 
@@ -56,12 +56,12 @@ describe('Community service', () => {
   })
 
   it('should fail silently', async () => {
-    moxios.stubRequest(`${apiUrl}/offender/D123456/convictions`, {
+    moxios.stubRequest(`${apiUrl}/offender/D123456/probation-record`, {
       status: 500,
       response: {}
     })
     expect(async () => {
-      await getConvictions('D123456')
+      await getProbationRecord('D123456')
     }).not.toThrow()
   })
 })


### PR DESCRIPTION
As part of the work to populate some dev data that corresponds to test data in Delius I've updated the court-case-service endpoint that prepare-a-case is calling now that it has been implemented. 

The tests still all pass as I've updated the mocks as well but there will need to be some further fixes as there are some fields which differ between the mocks and what the court-case-service returns. I'll raise fixing this as [a separate story](https://dsdmoj.atlassian.net/browse/PIC-369).