### PR TITLE
PIC-416 Bugfix: Attendance data requested on inactive orders

### DIFF
--- a/routes/view.js
+++ b/routes/view.js
@@ -70,10 +70,14 @@ router.get('/case/:caseNo/:section?/:detail?', health, defaults, async (req, res
             personalDetails
           }
         } else {
-          const attendanceDetails = await getAttendanceDetails(response.crn, params.detail)
-          communityResponse = {
-            ...communityResponse,
-            attendanceDetails
+          const { active } = communityResponse.convictions
+            .find(conviction => conviction.convictionId.toString() === params.detail.toString())
+          if (active) {
+            const attendanceDetails = await getAttendanceDetails(response.crn, params.detail)
+            communityResponse = {
+              ...communityResponse,
+              attendanceDetails
+            }
           }
         }
       }


### PR DESCRIPTION
Corrected issue where attendance data was being requested for inactive orders.

Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>