### PR TITLE
Node security release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ executors:
     working_directory: ~/app
   builder:
     docker:
-      - image: circleci/node:12.17.0-browsers
+      - image: circleci/node:12.18.0-browsers
     working_directory: ~/app
 
 orbs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.17-buster-slim
+FROM node:12.18-buster-slim
 
 MAINTAINER MoJ Digital, Probation in Court <probation-in-court-team@digital.justice.gov.uk>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Prepare a case is a service that allows probation staff to prepare court cases.
 
 ## Prerequisities
 Before you begin, ensure you have met the following requirements:
-* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Erbium) >= v12.16.2
+* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Erbium) >= v12.18.0
+
+Or
+
+* You have Node.js (Fermium) >= v14.4.0
 
 For code quality the project adheres to [JavaScript Standard Style](https://standardjs.com/) which requires minimal configuration of your chosen IDE.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8405,9 +8405,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.6.0.tgz",
-      "integrity": "sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
+      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
     },
     "graceful-fs": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "url": "https://github.com/ministryofjustice/prepare-a-case.git"
   },
   "engines": {
-    "node": ">=12.17.0 <13.0.0 || >=14.3.0",
-    "yarn": "^1.19.0"
+    "node": ">=12.18.0 <13.0.0 || >=14.4.0"
   },
   "scripts": {
     "precommit": "npm run lint && npm run unit-test && npm run int-test",
@@ -74,7 +73,7 @@
     "debug": "4.1.1",
     "express": "4.17.1",
     "express-session": "1.17.1",
-    "govuk-frontend": "3.6.0",
+    "govuk-frontend": "3.7.0",
     "memorystore": "1.6.2",
     "moment": "2.26.0",
     "morgan": "1.10.0",


### PR DESCRIPTION
Updated builds to use Node.js LTS (Erbium) v12.18.0.
Updated development process to require Node.js LTS (Erbium) v12.18.0 or (Fermium) 14.4.0.
Updated README
Updated dependencies.
Removed Yarn version reference.