### PR TITLE
:lipstick: PIC-652: Added back to cases link

### DIFF
--- a/integration-tests/integration/common/common.spec.js
+++ b/integration-tests/integration/common/common.spec.js
@@ -66,16 +66,8 @@ And('I should see the following table headings', $data => {
   })
 })
 
-And('I should type in my username', () => {
-  cy.get('#username').type('katie.cawthorne')
-})
-
 And('I should logout', () => {
   cy.get('.moj-header__navigation-link').click()
-})
-
-And('I should type in my password', () => {
-  cy.get('#password').type('Hulksmash14')
 })
 
 And('I should not see the heading level {int} with text {string}', ($level, $text) => {

--- a/integration-tests/integration/features/case-summary.feature
+++ b/integration-tests/integration/features/case-summary.feature
@@ -11,7 +11,7 @@ Feature: Case summary
     And I should see the heading "Cases"
     And I should see the caption with the relevant court
     When I click the defendant name link
-    Then I should be on the "Case details" page
+    Then I should be on the "Case summary" page
     And I should see the heading has the defendant name
     And There should be no a11y violations
 
@@ -19,10 +19,11 @@ Feature: Case summary
     Given I am an authenticated user
     And I am looking at a not matched defendant
 
-    When I navigate to the case details route
-    Then I should be on the "Case details" page
+    When I navigate to the case summary route
+    Then I should be on the "Case summary" page
+    And I should see Back to cases link with href of case list date
     And I should see sub navigation with the following links
-      | Case details |
+      | Case summary |
     And I should see the heading has the defendant name
     And I should see the body text "Probation status: Possible nDelius record"
     And I should see a straight line divide
@@ -51,10 +52,11 @@ Feature: Case summary
     Given I am an authenticated user
     And I am looking at a not known defendant
 
-    When I navigate to the case details route
-    Then I should be on the "Case details" page
+    When I navigate to the case summary route
+    Then I should be on the "Case summary" page
+    And I should see Back to cases link with href of case list date
     And I should see sub navigation with the following links
-      | Case details |
+      | Case summary |
     And I should see the heading has the defendant name
     And I should see the body text "Date of birth:" and the defendant "dateOfBirth"
     And I should see the body text "PNC:" and the defendant "pnc"
@@ -87,10 +89,11 @@ Feature: Case summary
     Given I am an authenticated user
     And I am looking at a previously known defendant
 
-    When I navigate to the case details route
-    Then I should be on the "Case details" page
+    When I navigate to the case summary route
+    Then I should be on the "Case summary" page
+    And I should see Back to cases link with href of case list date
     And I should see sub navigation with the following links
-      | Case details | Probation record | Risk register |
+      | Case summary | Probation record | Risk register |
     And I should see the heading has the defendant name
     And I should see the body text "Date of birth:" and the defendant "dateOfBirth"
     And I should see the body text "CRN:" and the defendant "crn"
@@ -124,10 +127,11 @@ Feature: Case summary
     Given I am an authenticated user
     And I am looking at a current defendant
 
-    When I navigate to the case details route
-    Then I should be on the "Case details" page
+    When I navigate to the case summary route
+    Then I should be on the "Case summary" page
+    And I should see Back to cases link with href of case list date
     And I should see sub navigation with the following links
-      | Case details | Probation record | Risk register |
+      | Case summary | Probation record | Risk register |
     And I should see the heading has the defendant name
     And I should see the body text "Date of birth:" and the defendant "dateOfBirth"
     And I should see the body text "CRN:" and the defendant "crn"
@@ -161,10 +165,11 @@ Feature: Case summary
     Given I am an authenticated user
     And I am looking at a current defendant with breach
 
-    When I navigate to the case details route
-    Then I should be on the "Case details" page
+    When I navigate to the case summary route
+    Then I should be on the "Case summary" page
+    And I should see Back to cases link with href of case list date
     And I should see sub navigation with the following links
-      | Case details | Probation record | Risk register |
+      | Case summary | Probation record | Risk register |
     And I should see the heading has the defendant name
     And I should see the body text "Date of birth:" and the defendant "dateOfBirth"
     And I should see the body text "CRN:" and the defendant "crn"
@@ -205,7 +210,8 @@ Feature: Case summary
     And I should see the heading "Cases"
     And I should see the caption with the relevant court
     When I click the defendant name link
-    Then I should be on the "Case details" page
+    Then I should be on the "Case summary" page
+    And I should see Back to cases link with href of case list date
     And I should see the heading has the defendant name
     When I click the sub navigation with "Probation record" text
     Then I should see the offender previous order count
@@ -363,10 +369,10 @@ Feature: Case summary
     And I should not see the heading level 2 with text "Unpaid work"
     And There should be no a11y violations
 
-  Scenario: View the case details of a defendant to see a list of current charges and the associated details/description
+  Scenario: View the case details of a defendant to see a list of current charges and the associated summary/description
     Given I am an authenticated user
     And I am looking at a current defendant
-    When I navigate to the case details route
+    When I navigate to the case summary route
     Then I should see the level 2 heading "Offences"
     And If the total number of charges is greater than one
     Then I should see a list of charges in an accordion component

--- a/integration-tests/integration/features/case-summary/case-summary.spec.js
+++ b/integration-tests/integration/features/case-summary/case-summary.spec.js
@@ -32,8 +32,12 @@ And('I am looking at a current defendant with breach', () => {
   world.scenario = 'currentDefendantWithBreach'
 })
 
-When('I navigate to the case details route', () => {
-  cy.visit(`case/${world.data.caseNo}/details`)
+And('I should see Back to cases link with href of case list date', () => {
+  cy.get('.govuk-back-link').contains('Back to cases').should('exist').should('have.attr', 'href').and('include', `${moment().format('YYYY-MM-DD')}`)
+})
+
+When('I navigate to the case summary route', () => {
+  cy.visit(`case/${world.data.caseNo}/summary`)
 })
 
 When('I navigate to the probation record route', () => {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -46,6 +46,7 @@ module.exports = function Index ({ authenticationMiddleware }) {
       data: response.cases.slice(startCount, endCount) || []
     }
     req.session.currentView = params.subsection
+    req.session.caseListDate = params.date
     res.render('case-list', templateValues)
   })
 
@@ -62,8 +63,10 @@ module.exports = function Index ({ authenticationMiddleware }) {
   async function getCaseAndTemplateValues (req) {
     const params = req.params
     const response = await getCase(params.courtCode, params.caseNo)
+    const caseListDate = req.session.caseListDate
     return {
       healthy: req.healthy,
+      caseListDate,
       params: {
         ...params
       },
@@ -73,9 +76,9 @@ module.exports = function Index ({ authenticationMiddleware }) {
     }
   }
 
-  router.get('/case/:caseNo/details', health, defaults, async (req, res) => {
+  router.get('/case/:caseNo/summary', health, defaults, async (req, res) => {
     const templateValues = await getCaseAndTemplateValues(req)
-    templateValues.title = 'Case details'
+    templateValues.title = 'Case summary'
 
     res.render('case-summary', templateValues)
   })

--- a/server/views/case-list.njk
+++ b/server/views/case-list.njk
@@ -31,7 +31,7 @@
         {{ offences.push('</ol>') }}
     {% endif %}
     {%- set tableRow = [
-            { text: ('<a href="/case/' + item.caseNo + '/details" class="pac-defendant-link govuk-link govuk-link--no-visited-state">' + item.defendantName | escape + '</a>') | safe },
+            { text: ('<a href="/case/' + item.caseNo + '/summary" class="pac-defendant-link govuk-link govuk-link--no-visited-state">' + item.defendantName | escape + '</a>') | safe },
             { text: ('<div>' + ('<span class="moj-badge moj-badge--red pac-badge">Possible nDelius Record</span>' | safe if item.numberOfPossibleMatches) + ('<span class="moj-badge moj-badge--black pac-badge">Breach</span>' | safe if item.breach) + ('<span class="moj-badge moj-badge--black pac-badge" style="">Sso</span>' | safe if item.suspendedSentenceOrder) + '</div>'+ item.probationStatus + ('<span data-cy="previously-known-termination-date" class="govuk-caption-m">Order ended ' + moment(item.previouslyKnownTerminationDate).format("D MMMM YYYY") | escape + '</span>' if item.previouslyKnownTerminationDate)) | safe },
             { text: offences | join('') | safe },
             { text: item.listNo },

--- a/server/views/case-summary-record-order-breach.njk
+++ b/server/views/case-summary-record-order-breach.njk
@@ -3,6 +3,8 @@
 
 {%- set moment = params.moment -%}
 
+{% block backlink %}{% endblock %}
+
 {% block caseContent %}
 
     {%- set breach = data.communityData -%}

--- a/server/views/case-summary-record-order.njk
+++ b/server/views/case-summary-record-order.njk
@@ -112,6 +112,8 @@
     {% endfor %}
 {% endif %}
 
+{% block backlink %}{% endblock %}
+
 {% block caseContent %}
 
     {%- from "govuk/components/back-link/macro.njk" import govukBackLink -%}

--- a/server/views/case-summary-risk.njk
+++ b/server/views/case-summary-risk.njk
@@ -1,5 +1,6 @@
 {% extends "partials/case-details.njk" %}
 
+
 {% block caseContent %}
 
     <div class="govuk-grid-row">

--- a/server/views/case-summary.njk
+++ b/server/views/case-summary.njk
@@ -8,16 +8,6 @@
     </h2>
 {% endset %}
 
-{% block backlink %}
-
-    {%- from "govuk/components/back-link/macro.njk" import govukBackLink -%}
-    {{ govukBackLink({
-        text: "Back to cases",
-        href: '/cases/' + caseListDate
-    }) }}
-
-{% endblock %}
-
 {% block caseContent %}
 
     {% if data.numberOfPossibleMatches > 0 %}

--- a/server/views/case-summary.njk
+++ b/server/views/case-summary.njk
@@ -8,6 +8,16 @@
     </h2>
 {% endset %}
 
+{% block backlink %}
+
+    {%- from "govuk/components/back-link/macro.njk" import govukBackLink -%}
+    {{ govukBackLink({
+        text: "Back to cases",
+        href: '/cases/' + caseListDate
+    }) }}
+
+{% endblock %}
+
 {% block caseContent %}
 
     {% if data.numberOfPossibleMatches > 0 %}
@@ -21,7 +31,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-l">Case details</h1>
+            <h1 class="govuk-heading-l">Case summary</h1>
         </div>
     </div>
 

--- a/server/views/partials/case-details.njk
+++ b/server/views/partials/case-details.njk
@@ -3,9 +3,9 @@
 {%- set moment = params.moment -%}
 
 {% set subNavItems = [{
-    text: 'Case details',
-    href: '/case/' + data.caseNo + '/details',
-    active: title === 'Case details'
+    text: 'Case summary',
+    href: '/case/' + data.caseNo + '/summary',
+    active: title === 'Case summary'
 }] %}
 
 {% if data.probationStatus === 'Current' or data.probationStatus === 'Previously known' %}

--- a/server/views/partials/case-details.njk
+++ b/server/views/partials/case-details.njk
@@ -51,6 +51,16 @@
 
 {% endblock %}
 
+{% block backlink %}
+
+    {%- from "govuk/components/back-link/macro.njk" import govukBackLink -%}
+    {{ govukBackLink({
+        text: "Back to cases",
+        href: '/cases/' + caseListDate
+    }) }}
+
+{% endblock %}
+
 {% block content %}
 
     {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}

--- a/tests/routes/view.test.js
+++ b/tests/routes/view.test.js
@@ -114,7 +114,7 @@ describe('Routes', () => {
   })
 
   it('case summary details route should call the case service to fetch case data', async () => {
-    const response = await request(app).get('/case/8678951874/details')
+    const response = await request(app).get('/case/8678951874/summary')
     expect(caseService.getCase).toHaveBeenCalledWith('SHF', '8678951874')
     return response
   })


### PR DESCRIPTION
- Added back to cases link on Case summary page that will take the user back to the case list they were viewing
- Noticed on the prototype that the page is no longer called 'Case details' but instead 'Case summary' - updated content to align with prototype.
- Updated `/details` endpoint to `/summary` with the UI now being referred to as 'Case summary'
- Added integration tests for back to cases link
- Ticket also mentions adding link to `Cases` to take the user to the latest case list but this has already been implemented.