### PR TITLE
BUGFIX - Possible records and probation status are displayed together

### DIFF
--- a/integration-tests/integration/features/matching.feature
+++ b/integration-tests/integration/features/matching.feature
@@ -132,6 +132,24 @@ Feature: Matching defendants to nDelius records
     Then I should see the error message "Enter the CRN in the correct format"
     And There should be no a11y violations
 
+  Scenario: Manually match a defendant and submit with a valid but incorrect CRN
+    Given I am an authenticated user
+    When I navigate to the "/match/bulk/" route for today
+    And I am using the "bulkList" match data
+    Then I should be on the "Defendants with possible nDelius records" page
+    When I click the "Review records" link
+    Then I should be on the "Review possible nDelius records" page
+    And I am using the "defendantOneRecords" match data
+    And I click the element with id "defendant-1"
+    And I click the "Can't see the correct record?" summary link
+    And I click the "link it to them with a case reference number" link
+    Then I should be on the "Link an nDelius record to the defendant" page
+    When I enter "A123456" into text input with id "crn"
+    And I click the "Find record" button
+    Then I should be on the "Link an nDelius record to the defendant" page
+    Then I should see the error message "No records match the CRN provided"
+    And There should be no a11y violations
+
   Scenario: Manually match a defendant from the bulk list
     Given I am an authenticated user
     When I navigate to the "/match/bulk/" route for today
@@ -197,69 +215,6 @@ Feature: Matching defendants to nDelius records
     Then I should be on the "Link an nDelius record to the defendant" page
     And I should see the level 3 heading "Enter the CRN of the existing record"
     And There should be no a11y violations
-
-  Scenario: Manually match a defendant from the bulk list
-    Given I am an authenticated user
-    When I navigate to the "/match/bulk/" route for today
-    And I am using the "bulkList" match data
-    Then I should be on the "Defendants with possible nDelius records" page
-    When I click the "Review records" link
-    Then I should be on the "Review possible nDelius records" page
-    And I am using the "defendantOneRecords" match data
-    And I click the element with id "defendant-1"
-    And I click the "Can't see the correct record?" summary link
-    And I click the "link it to them with a case reference number" link
-    Then I should be on the "Link an nDelius record to the defendant" page
-    When I enter "C178657" into text input with id "crn"
-    And I click the "Find record" button
-    Then I should be on the "Link an nDelius record to the defendant" page
-    And I should see the body text "Use a case reference number (CRN) to link to an existing nDelius record to the defendant."
-    And I should see the level 2 heading "Defendant details"
-    And I should see the following table headings
-      | Name | Date of birth |
-    And I should see the level 3 heading "nDelius record found"
-    And I should see the following table 2 headings
-      | Name | Date of birth | CRN | PNC | Probation status |
-    When I click the "Link record to defendant" button
-    Then I should be on the "Defendants with possible nDelius records" page
-    And I should see the match confirmation banner message
-
-  Scenario: Manually match a defendant from the case list
-    Given I am an authenticated user
-    When I navigate to the "match/defendant/3597035492" route
-    And I am using the "defendantOneRecords" match data
-    And I should see the defendant record options
-    And I click the element with id "defendant-1"
-    And I click the "Can't see the correct record?" summary link
-    And I click the "link it to them with a case reference number" link
-    Then I should be on the "Link an nDelius record to the defendant" page
-    When I enter "C178657" into text input with id "crn"
-    And I click the "Find record" button
-    Then I should be on the "Link an nDelius record to the defendant" page
-    And I should see the body text "Use a case reference number (CRN) to link to an existing nDelius record to the defendant."
-    And I should see the level 2 heading "Defendant details"
-    And I should see the following table headings
-      | Name | Date of birth |
-    And I should see the level 3 heading "nDelius record found"
-    And I should see the following table 2 headings
-      | Name | Date of birth | CRN | PNC | Probation status |
-    When I click the "Link record to defendant" button
-    Then I should be on the "Case summary" page
-    And I should see the match confirmation banner message
-
-  Scenario: Manually match a defendant and choose to search again
-    Given I am an authenticated user
-    And I am using the "defendantOneRecords" match data
-    When I navigate to the "/match/defendant/3597035492/confirm/C178657" route
-    Then I should be on the "Link an nDelius record to the defendant" page
-    And I should see the body text "Use a case reference number (CRN) to link to an existing nDelius record to the defendant."
-    And I should see the level 2 heading "Defendant details"
-    And I should see the following table headings
-      | Name | Date of birth |
-    And I should see the level 3 heading "nDelius record found"
-    When I click the "Search again" link
-    Then I should be on the "Link an nDelius record to the defendant" page
-    And I should see the level 3 heading "Enter the CRN of the existing record"
 
   Scenario: Confirm no existing defendant record match from case summary
     Given I am an authenticated user

--- a/integration-tests/integration/world/data/case-list/addedCasesList.js
+++ b/integration-tests/integration/world/data/case-list/addedCasesList.js
@@ -5,8 +5,8 @@ const addedCasesList = {
       {
         defendant: 'Sara Ortega',
         probationStatus: 'Previously known',
-        breach: true,
-        sso: true,
+        breach: false,
+        sso: false,
         offence: '*Assault by beating',
         listing: '3rd',
         session: 'Morning',
@@ -16,7 +16,7 @@ const addedCasesList = {
         defendant: 'Obrien Mccall',
         probationStatus: 'No record',
         breach: false,
-        sso: true,
+        sso: false,
         offence: '*Theft from a shop',
         listing: '2nd',
         session: 'Morning',
@@ -25,6 +25,8 @@ const addedCasesList = {
       {
         defendant: 'Lloyd Humphrey',
         probationStatus: 'Previously known',
+        breach: false,
+        sso: false,
         offence: '*Assault by beating',
         listing: '1st',
         session: 'Morning',
@@ -33,6 +35,8 @@ const addedCasesList = {
       {
         defendant: 'Janis Woods',
         probationStatus: 'No record',
+        breach: false,
+        sso: false,
         offence: '*Theft from a shop',
         listing: '3rd',
         session: 'Morning',

--- a/integration-tests/integration/world/data/case-list/fullFilteredList.js
+++ b/integration-tests/integration/world/data/case-list/fullFilteredList.js
@@ -4,7 +4,7 @@ const fullFilteredList = {
       name: 'Kara Ayers'
     },
     filtered: {
-      name: 'Felicia Villarreal'
+      name: 'Porter Salas'
     }
   }
 }

--- a/integration-tests/integration/world/data/case-list/probationStatusFilteredList.js
+++ b/integration-tests/integration/world/data/case-list/probationStatusFilteredList.js
@@ -4,7 +4,7 @@ const probationStatusFilteredList = {
       name: 'Kara Ayers'
     },
     filtered: {
-      name: 'Felicia Villarreal'
+      name: 'Lenore Marquez'
     }
   }
 }

--- a/mappings/case-list-full.json
+++ b/mappings/case-list-full.json
@@ -28,7 +28,7 @@
           "probationStatus": "No record",
           "session": "MORNING",
           "previouslyKnownTerminationDate": null,
-          "suspendedSentenceOrder": true,
+          "suspendedSentenceOrder": false,
           "breach": false,
           "offences": [
             {
@@ -119,7 +119,7 @@
           "courtRoom": "07",
           "sessionStartTime": "{{now format='yyyy-MM-dd'}}T09:30:00",
           "listNo": "3rd",
-          "crn": "D985513",
+          "crn": null,
           "pnc": "A/1234560BA",
           "probationStatus": "",
           "numberOfPossibleMatches": 3,
@@ -162,8 +162,8 @@
           "probationStatus": "Previously Known",
           "session": "AFTERNOON",
           "previouslyKnownTerminationDate": "2010-01-01",
-          "suspendedSentenceOrder": true,
-          "breach": true,
+          "suspendedSentenceOrder": false,
+          "breach": false,
           "offences": [
             {
               "offenceTitle": "Theft from the person of another",
@@ -195,8 +195,9 @@
           "courtRoom": "01",
           "sessionStartTime": "{{now format='yyyy-MM-dd'}}T09:30:00",
           "listNo": "3rd",
+          "crn": null,
           "pnc": "A/1234560BA",
-          "probationStatus": "Current",
+          "probationStatus": "",
           "numberOfPossibleMatches": 2,
           "session": "AFTERNOON",
           "previouslyKnownTerminationDate": null,
@@ -252,7 +253,7 @@
           "probationStatus": "Previously Known",
           "session": "MORNING",
           "previouslyKnownTerminationDate": null,
-          "suspendedSentenceOrder": true,
+          "suspendedSentenceOrder": false,
           "breach": false,
           "offences": [
             {
@@ -295,8 +296,8 @@
           "probationStatus": "Previously Known",
           "session": "MORNING",
           "previouslyKnownTerminationDate": "2010-01-01",
-          "suspendedSentenceOrder": true,
-          "breach": true,
+          "suspendedSentenceOrder": false,
+          "breach": false,
           "offences": [
             {
               "offenceTitle": "Assault by beating",
@@ -343,7 +344,7 @@
           "session": "MORNING",
           "previouslyKnownTerminationDate": "2013-01-01",
           "suspendedSentenceOrder": false,
-          "breach": true,
+          "breach": false,
           "offences": [
             {
               "offenceTitle": "Theft from the person of another",
@@ -374,8 +375,8 @@
           "probationStatus": "Previously Known",
           "session": "MORNING",
           "previouslyKnownTerminationDate": "2016-01-01",
-          "suspendedSentenceOrder": true,
-          "breach": true,
+          "suspendedSentenceOrder": false,
+          "breach": false,
           "offences": [
             {
               "offenceTitle": "Theft from a shop",
@@ -538,7 +539,7 @@
           "probationStatus": "Previously Known",
           "session": "MORNING",
           "previouslyKnownTerminationDate": "2010-01-01",
-          "suspendedSentenceOrder": true,
+          "suspendedSentenceOrder": false,
           "breach": false,
           "offences": [
             {
@@ -642,7 +643,7 @@
           "probationStatus": "Previously Known",
           "session": "MORNING",
           "previouslyKnownTerminationDate": "2010-01-01",
-          "suspendedSentenceOrder": true,
+          "suspendedSentenceOrder": false,
           "breach": false,
           "offences": [
             {
@@ -8359,7 +8360,7 @@
           "probationStatus": "No record",
           "session": "MORNING",
           "previouslyKnownTerminationDate": null,
-          "suspendedSentenceOrder": true,
+          "suspendedSentenceOrder": false,
           "breach": false,
           "offences": [
             {
@@ -8410,7 +8411,7 @@
           "probationStatus": "Previously Known",
           "session": "MORNING",
           "previouslyKnownTerminationDate": "2019-11-12",
-          "suspendedSentenceOrder": true,
+          "suspendedSentenceOrder": false,
           "breach": false,
           "offences": [
             {

--- a/mappings/matching/default-detail.json
+++ b/mappings/matching/default-detail.json
@@ -1,0 +1,14 @@
+{
+  "id": "8f01aebb-b27e-4082-a5fb-8675fc772424",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/(?!C178657|V178657)([A-Za-z][0-9]{6})/detail"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 400,
+    "jsonBody": {}
+  }
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -262,6 +262,7 @@ module.exports = function Index ({ authenticationMiddleware }) {
     req.session.serverError = false
     req.session.formError = false
     req.session.formInvalid = false
+    req.session.crnInvalid = false
     req.session.confirmedMatch = undefined
     if (!req.body.crn) {
       req.session.formError = true
@@ -271,7 +272,15 @@ module.exports = function Index ({ authenticationMiddleware }) {
       req.session.formInvalid = true
       redirectUrl = `/match/defendant/${req.params.caseNo}/manual`
     } else {
-      redirectUrl = `/match/defendant/${req.params.caseNo}/confirm/${req.body.crn}`
+      const detailResponse = await getDetails(req.body.crn)
+      console.info('DETAILS:', detailResponse)
+      if (!detailResponse) {
+        req.session.formError = true
+        req.session.crnInvalid = true
+        redirectUrl = `/match/defendant/${req.params.caseNo}/manual`
+      } else {
+        redirectUrl = `/match/defendant/${req.params.caseNo}/confirm/${req.body.crn}`
+      }
     }
     res.redirect(redirectUrl)
   })

--- a/server/views/case-list.njk
+++ b/server/views/case-list.njk
@@ -33,7 +33,7 @@
     {% endif %}
     {%- set tableRow = [
             { text: ('<a href="/case/' + item.caseNo + '/summary" class="pac-defendant-link govuk-link govuk-link--no-visited-state">' + item.defendantName | escape + '</a>') | safe },
-            { text: ('<div>' + ('<span class="moj-badge moj-badge--red pac-badge">Possible nDelius Record</span>' | safe if item.numberOfPossibleMatches) + ('<span class="moj-badge moj-badge--black pac-badge">Breach</span>' | safe if item.breach) + ('<span class="moj-badge moj-badge--black pac-badge">Sso</span>' | safe if item.suspendedSentenceOrder) + '</div>'+ (item.probationStatus | capitalize) + ('<span data-cy="previously-known-termination-date" class="govuk-caption-m">Order ended ' + moment(item.previouslyKnownTerminationDate).format("D MMMM YYYY") | escape + '</span>' if item.previouslyKnownTerminationDate)) | safe },
+            { text: ('<div>' + ('<span class="moj-badge moj-badge--red pac-badge">Possible nDelius Record</span>' | safe if item.numberOfPossibleMatches > 1 and not item.crn ) + ('<span class="moj-badge moj-badge--black pac-badge">Breach</span>' | safe if item.breach) + ('<span class="moj-badge moj-badge--black pac-badge">Sso</span>' | safe if item.suspendedSentenceOrder) + '</div>'+ (item.probationStatus | capitalize) + ('<span data-cy="previously-known-termination-date" class="govuk-caption-m">Order ended ' + moment(item.previouslyKnownTerminationDate).format("D MMMM YYYY") | escape + '</span>' if item.previouslyKnownTerminationDate)) | safe },
             { text: offences | join('') | safe },
             { text: item.listNo },
             { text: item.session | capitalize },

--- a/server/views/case-summary.njk
+++ b/server/views/case-summary.njk
@@ -16,7 +16,7 @@
         matchType: session.confirmedMatch.matchType
     }) }}
 
-    {% if data.numberOfPossibleMatches > 0 and not session.confirmedMatch.name %}
+    {% if data.numberOfPossibleMatches > 1 and not data.crn %}
         {%- from "moj/components/banner/macro.njk" import mojBanner -%}
         {{ mojBanner({
             classes: 'govuk-!-display-inline-block',
@@ -71,7 +71,6 @@
                     {% endfor %}
                 </div>
             {% endif %}
-
 
             <h2 class="govuk-heading-m govuk-!-margin-top-9">
                 Defendant details

--- a/server/views/match-manual.njk
+++ b/server/views/match-manual.njk
@@ -21,6 +21,9 @@
         {% if session.formInvalid %}
             {%- set errorText = "Enter the CRN in the correct format" -%}
         {% endif %}
+        {% if session.crnInvalid %}
+            {%- set errorText = "No records match the CRN provided" -%}
+        {% endif %}
         {{ govukErrorSummary({
             titleText: "There is a problem",
             errorList: [
@@ -60,13 +63,8 @@
                     {% from "govuk/components/input/macro.njk" import govukInput %}
                     {% if session.formError %}
                         {%- set errorMessage = {
-                            text: "You must enter a case reference number"
+                            text: errorText
                         } -%}
-                        {% if session.formInvalid %}
-                            {%- set errorMessage = {
-                                text: "Enter the CRN in the correct format"
-                            } -%}
-                        {% endif %}
                     {% endif %}
                     {{ govukInput({
                         label: { text: "Case reference number (CRN)" },


### PR DESCRIPTION
Includes CRN lookup and error message that was missed on PIC-647 (sorry)
Removed duplicate scenarios from BDD resulting from merge
Made 1st page of case list data more consistent with real data (no longer shows breach and SSO for defendants without a current order)

Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>