### PR TITLE
Pic 679 prototype alignment

### DIFF
--- a/public/stylesheets/app/_key-details.scss
+++ b/public/stylesheets/app/_key-details.scss
@@ -1,6 +1,6 @@
 .pac-key-details-bar {
   background-color: $govuk-brand-colour;
-  
+
   &__right-block{
     float: right;
     @include govuk-clearfix();
@@ -11,10 +11,6 @@
     h1, .govuk-body {
       color: govuk-colour("white");
     }
-  }
-
-  &__bottom-block {
-    margin-top: 10px;
   }
 
   &__key-details {

--- a/public/stylesheets/app/_key-details.scss
+++ b/public/stylesheets/app/_key-details.scss
@@ -13,6 +13,11 @@
     }
   }
 
+  &__bottom-block{
+    padding-top: 10px;
+    margin-top: 6px;
+  }
+
   &__key-details {
     @include moj-width-container;
     margin: 0 auto;

--- a/server/views/case-summary-record-order.njk
+++ b/server/views/case-summary-record-order.njk
@@ -112,16 +112,15 @@
     {% endfor %}
 {% endif %}
 
-{% block backlink %}{% endblock %}
-
-{% block caseContent %}
-
+{% block backlink %}
     {%- from "govuk/components/back-link/macro.njk" import govukBackLink -%}
     {{ govukBackLink({
-        classes: 'govuk-!-margin-top-0 govuk-!-margin-bottom-7',
         text: "Back to probation record",
         href: '/case/' + data.caseNo + '/record'
     }) }}
+{% endblock %}
+
+{% block caseContent %}
 
     <h2 class="govuk-heading-l govuk-!-margin-0">{{ currentOrder.sentence.description }}</h2>
 

--- a/server/views/components/key-details-bar/template.njk
+++ b/server/views/components/key-details-bar/template.njk
@@ -1,30 +1,33 @@
 <section class="pac-key-details-bar" aria-label="Key details">
-  <div class="pac-key-details-bar__key-details">
-  {% if params.probationStatus == 'No record' %}
-   <div class="pac-key-details-bar__right-block">
-      <form method="get" action="/match/defendant/{{ params.caseNo }}/manual"><button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" type="submit">
-        Link nDelius record
-      </button>
-      </form>
-    </div>
-    {% endif %}
+    <div class="pac-key-details-bar__key-details">
+        {% if params.probationStatus == 'No record' %}
+            <div class="pac-key-details-bar__right-block">
+                <form method="get" action="/match/defendant/{{ params.caseNo }}/manual">
+                    <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0"
+                            data-module="govuk-button" type="submit">
+                        Link nDelius record
+                    </button>
+                </form>
+            </div>
+        {% endif %}
 
-    <div class="pac-key-details-bar__top-block">
-      <h1 class="pac-key-details-bar__name govuk-!-margin-right-6">{% if params.accTitle %}<span class="govuk-visually-hidden">{{ params.accTitle }}</span>{% endif %}{{ params.title }}</h1>
-      {% if params.crn | length %}
-        <span class="govuk-body pac-key-details-bar__divider"><strong>CRN: </strong>{{ params.crn }}</span>
-      {% endif %}
-      {% if params.pnc and not params.numberOfPossibleMatches and not (params.probationStatus == 'No record') %}
-        <span class="govuk-body pac-key-details-bar__divider"><strong>PNC: </strong>{{ params.pnc }}</span>
-      {% endif %}
-      {% if params.numberOfPossibleMatches %}
-        <span class="govuk-body pac-key-details-bar__divider"><strong>Probation status: </strong> Possible nDelius record</span>
-      {% endif %}
+        <div class="pac-key-details-bar__top-block">
+            <h1 class="pac-key-details-bar__name govuk-!-margin-right-6">{% if params.accTitle %}<span
+                        class="govuk-visually-hidden">{{ params.accTitle }}</span>{% endif %}{{ params.title }}</h1>
+            {% if params.crn | length %}
+                <span class="govuk-body pac-key-details-bar__divider"><strong>CRN: </strong>{{ params.crn }}</span>
+            {% endif %}
+            {% if params.pnc and not params.numberOfPossibleMatches and not (params.probationStatus == 'No record') %}
+                <span class="govuk-body pac-key-details-bar__divider"><strong>PNC: </strong>{{ params.pnc }}</span>
+            {% endif %}
+            {% if params.numberOfPossibleMatches %}
+                <span class="govuk-body pac-key-details-bar__divider"><strong>Probation status: </strong> Possible nDelius record</span>
+            {% endif %}
+        </div>
+        {% if params.probationStatus and not params.numberOfPossibleMatches %}
+        <div class="pac-key-details-bar__bottom-block">
+            <span class="govuk-body pac-key-details-bar__divider"><strong>Probation status: </strong>{{ params.probationStatus }}{% if params.breach %} (Breach){% endif %}</span>
+        </div>
+        {% endif %}
     </div>
-    <div class="pac-key-details-bar__bottom-block">
-      {% if params.probationStatus and not params.numberOfPossibleMatches %}
-        <span class="govuk-body pac-key-details-bar__divider"><strong>Probation status: </strong>{{ params.probationStatus }}{% if params.breach  %} (Breach){% endif %}</span>
-      {% endif %}
-    </div>
-  </div>
 </section>


### PR DESCRIPTION
2 small changes following meeting with Charan and Alastair regarding PIC-679 (prototype front end alignment)
- suppress `pac-key-details-bar__bottom-block` if there's no probation status
- On view `case-summary-record-order` moved back link out of main content and into backLink block so displayed the same as other pages