### PR TITLE
:bug: PIC-726: fixed invalid date

### DIFF
--- a/mappings/community/D541487-convictions.json
+++ b/mappings/community/D541487-convictions.json
@@ -40,12 +40,14 @@
             }
           ],
           "sentence": {
+            "sentenceId": "123123140",
             "description": "CJA - Indeterminate Public Prot.",
             "length": 18,
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2019-07-12",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-01-06"
           },
           "documents": []
         },
@@ -64,12 +66,14 @@
             }
           ],
           "sentence": {
+            "sentenceId": "123123141",
             "description": "Adult Custody < 12m",
             "length": 18,
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2019-01-13",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-09-23"
           },
           "documents": [
             {
@@ -106,12 +110,14 @@
             }
           ],
           "sentence": {
+            "sentenceId": "123123142",
             "description": "CJA - Indeterminate Public Prot.",
             "length": 18,
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-12-03",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-12-24"
           },
           "documents": []
         },
@@ -133,12 +139,14 @@
             }
           ],
           "sentence": {
+            "sentenceId": "123123143",
             "description": "ORA Community Order",
             "length": 18,
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-12-03",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-08-13"
           },
           "documents": []
         },
@@ -154,12 +162,14 @@
               }
           ],
           "sentence": {
+            "sentenceId": "123123144",
             "description": "ORA Suspended Sentence Order",
             "length": 18,
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-12-03",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-11-14"
           },
           "documents": []
         }

--- a/mappings/community/D814575-convictions.json
+++ b/mappings/community/D814575-convictions.json
@@ -37,12 +37,14 @@
             }
           ],
           "sentence": {
+            "sentenceId": "123123141",
             "description": "CJA - Indeterminate Public Prot.",
             "length": 18,
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-06",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-06"
           },
           "documents": []
         },
@@ -67,12 +69,14 @@
             }
           ],
           "sentence": {
+            "sentenceId": "123123142",
             "description": "ORA Suspended Sentence Order",
             "length": 18,
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-07-24",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-01-24"
           },
           "documents": []
         }

--- a/mappings/community/D985513-convictions.json
+++ b/mappings/community/D985513-convictions.json
@@ -34,12 +34,14 @@
               }
           ],
           "sentence": {
+            "sentenceId": "123123141",
             "description": "CJA - Std Determinate Custody",
             "length": 18,
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-05-23",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-11-23"
           },
           "documents": [
             {

--- a/mappings/community/D991494-convictions.json
+++ b/mappings/community/D991494-convictions.json
@@ -43,7 +43,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-01",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-01"
           },
           "documents": []
         },
@@ -68,7 +69,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-08-09",
-            "terminationReason":  "ICMS Miscellaneous Event"
+            "terminationReason":  "ICMS Miscellaneous Event",
+            "startDate": "2018-02-09"
           },
           "documents": []
         },
@@ -116,7 +118,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-04-07",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate":  "2018-10-07"
           },
           "documents": [
             {
@@ -156,7 +159,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-12-12",
-            "terminationReason":  "ICMS Miscellaneous Event"
+            "terminationReason":  "ICMS Miscellaneous Event",
+            "startDate": "2018-06-12"
           },
           "documents": []
         },
@@ -187,7 +191,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-07-12",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-11-12"
           },
           "documents": []
         },
@@ -209,7 +214,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-07-03",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-01-03"
           },
           "documents": []
         },
@@ -237,7 +243,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-06-30",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-12-30"
           },
           "documents": []
         },
@@ -262,7 +269,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-08-21",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-02-21"
           },
           "documents": []
         },
@@ -290,7 +298,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-08-05",
-            "terminationReason":  "ICMS Miscellaneous Event"
+            "terminationReason":  "ICMS Miscellaneous Event",
+            "startDate": "2018-02-05"
           },
           "documents": []
         },
@@ -315,7 +324,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-03-30",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-09-30"
           },
           "documents": []
         },
@@ -343,7 +353,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-05-13",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-11-13"
           },
           "documents": []
         },
@@ -368,7 +379,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-02-24",
-            "terminationReason":  "ICMS Miscellaneous Event"
+            "terminationReason":  "ICMS Miscellaneous Event",
+            "startDate": "2018-08-24"
           },
           "documents": []
         },
@@ -392,7 +404,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-02",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-04"
           },
           "documents": []
         },
@@ -420,7 +433,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-06-26",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-12-26"
           },
           "documents": []
         },
@@ -445,7 +459,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-09-02",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-03-02"
           },
           "documents": []
         },
@@ -476,7 +491,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-02-13",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-08-13"
           },
           "documents": []
         },
@@ -498,7 +514,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-05-24",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-11-24"
           },
           "documents": []
         },
@@ -529,7 +546,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-07-24",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-01-24"
           },
           "documents": []
         },
@@ -551,7 +569,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-11-07",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-05-07"
           },
           "documents": []
         },
@@ -582,7 +601,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-05-26",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-11-26"
           },
           "documents": []
         },
@@ -613,7 +633,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-06-06",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-12-06"
           },
           "documents": []
         },
@@ -638,7 +659,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-09-10",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-03-10"
           },
           "documents": []
         },
@@ -663,7 +685,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-10-05",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-04-05"
           },
           "documents": []
         },
@@ -685,7 +708,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-23",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-23"
           },
           "documents": []
         },
@@ -710,7 +734,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-13",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-10-13"
           },
           "documents": []
         },
@@ -732,7 +757,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-10-13",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-04-18"
           },
           "documents": []
         },
@@ -754,7 +780,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-10-20",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-03-20"
           },
           "documents": []
         },
@@ -805,7 +832,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-30",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-30"
           },
           "documents": []
         },
@@ -844,7 +872,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-07-11",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-01-11"
           },
           "documents": []
         },
@@ -866,7 +895,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-07-14",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-01-14"
           },
           "documents": []
         },
@@ -891,7 +921,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-08-17",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-02-17"
           },
           "documents": []
         },
@@ -922,7 +953,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-08-09",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-02-09"
           },
           "documents": []
         },
@@ -950,7 +982,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-11-28",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-05-28"
           },
           "documents": []
         },
@@ -972,7 +1005,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-02-06",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-08-06"
           },
           "documents": []
         },
@@ -994,7 +1028,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-21",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-21"
           },
           "documents": []
         },
@@ -1019,7 +1054,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-07",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-07"
           },
           "documents": []
         },
@@ -1047,7 +1083,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-10-12",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-04-12"
           },
           "documents": []
         },
@@ -1072,7 +1109,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-11-31",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-05-31"
           },
           "documents": []
         },
@@ -1103,7 +1141,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-11-31",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-08-31"
           },
           "documents": []
         },
@@ -1128,7 +1167,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-05-05",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-11-05"
           },
           "documents": []
         },
@@ -1156,7 +1196,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-10-26",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-04-26"
           },
           "documents": []
         },
@@ -1178,7 +1219,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-11-09",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-05-09"
           },
           "documents": []
         },
@@ -1228,7 +1270,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-11-25",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-05-25"
           },
           "documents": []
         },
@@ -1272,7 +1315,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-02-18",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-08-18"
           },
           "documents": []
         },
@@ -1300,7 +1344,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-12-17",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-06-17"
           },
           "documents": []
         },
@@ -1325,7 +1370,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-03-10",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-09-10"
           },
           "documents": []
         },
@@ -1350,7 +1396,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2020-01-25",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-25"
           },
           "documents": []
         },
@@ -1378,7 +1425,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-11-18",
-            "terminationReason": "Auto Terminated"
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-05-18"
           },
           "documents": []
         },
@@ -1408,7 +1456,8 @@
             "lengthUnits": "Months",
             "lengthInDays": 547,
             "terminationDate": "2019-07-08",
-            "terminationReason":  "ICMS Miscellaneous Event"
+            "terminationReason":  "ICMS Miscellaneous Event",
+            "startDate":  "2018-01-08"
           },
           "documents": []
         }

--- a/mappings/community/DX12340A-convictions.json
+++ b/mappings/community/DX12340A-convictions.json
@@ -40,7 +40,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-01-23",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2017-03-08"
           },
           "documents": []
         },
@@ -62,7 +63,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2019-08-27",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2019-02-14"
           },
           "documents": []
         },
@@ -90,7 +92,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2017-08-09",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2017-02-21"
           },
           "documents": []
         },
@@ -112,7 +115,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2019-09-04",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2019-02-13"
           },
           "documents": []
         },
@@ -166,7 +170,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-01-23",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2017-02-12"
           },
           "documents": []
         },
@@ -174,7 +179,7 @@
           "convictionId": "1081636758",
           "active": false,
           "inBreach": true,
-          "convictionDate": "2017-02-26",
+          "convictionDate": "2019-05-19",
           "endDate": "2017-12-19",
           "offences": [
             {
@@ -188,7 +193,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2019-09-04",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2019-05-19"
           },
           "documents": []
         },
@@ -219,7 +225,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-01-23",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2019-05-19"
           },
           "documents": [
             {
@@ -280,7 +287,8 @@
               "pssEndDate": "{{now offset='12 months' format='yyyy-MM-dd'}}",
               "length": 12,
               "lengthUnit": "Months"
-            }
+            },
+            "startDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}"
           },
           "documents": [
             {
@@ -326,7 +334,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2017-12-25",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2017-02-21"
           },
           "documents": []
         },
@@ -382,7 +391,8 @@
               "pssEndDate": "{{now offset='5 months' format='yyyy-MM-dd'}}",
               "length": 11,
               "lengthUnit": "Months"
-            }
+            },
+            "startDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}"
           },
           "documents": []
         },
@@ -410,7 +420,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-08-04",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2018-02-25"
           },
           "documents": []
         },
@@ -432,7 +443,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-01-23",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2017-02-22"
           },
           "documents": []
         },
@@ -463,7 +475,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-09-21",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2018-03-01"
           },
           "documents": []
         },
@@ -488,7 +501,8 @@
             "lengthInDays": 547,
             "lengthUnits": "Months",
             "terminationDate": "2018-09-23",
-            "terminationReason": "ICMS Miscellaneous Event"
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2018-02-27"
           },
           "documents": []
         }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pre-commit-lite": "npm run lint && npm run unit-test && npm run mock-validation-test",
     "pre-push": "snyk test --fail-on=upgradable --org=digital-probation-services && npm run int-test",
     "start-feature": "PORT=3007 NODE_ENV=development node $NODE_DEBUG_OPTION ./bin/www | bunyan -o short",
-    "start-feature:dev": "PORT=3007 NODE_ENV=development nodemon $NODE_DEBUG_OPTION ./bin/www | bunyan -o short",
+    "start-feature:dev": "PORT=3007 NOMIS_AUTH_URL=http://localhost:9091/auth NODE_ENV=development nodemon $NODE_DEBUG_OPTION ./bin/www | bunyan -o short",
     "delete:reports": "rm ./test-results/cypress/* || true",
     "preint-test": "npm run delete:reports",
     "preint-test:dev": "npm run delete:reports",

--- a/server/views/case-summary-record-order.njk
+++ b/server/views/case-summary-record-order.njk
@@ -139,7 +139,7 @@
                         {%- if custodialOrder -%}
                             {{  "On licence" if custodialOrder.custodialTypeCode === "B" else "On post-sentence supervision (PSS)" }}
                         {% else %}
-                            {{ moment(currentOrder.convictionDate, 'YYYY-MM-DD').format(displayDateFormat) }}
+                            {{ moment(currentOrder.sentence.startDate, 'YYYY-MM-DD').format(displayDateFormat) }}
                         {% endif %}
                     </p>
                 </div>


### PR DESCRIPTION
Following investigations with Alastair it has been decided to use sentence startDate instead of convictionDate, due to convictionDate displaying null for cases over 5 years old.

- Replaced convictionDate with sentence.startDate
- Updated mock data to reflect live sentence data