### PR TITLE
Updated Node.js versions to security releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ executors:
     working_directory: ~/app
   builder:
     docker:
-      - image: circleci/node:12.18.3-browsers
+      - image: circleci/node:12.18.4-browsers
     working_directory: ~/app
 
 orbs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.3-alpine3.12
+FROM node:12.18.4-alpine3.12
 
 MAINTAINER MoJ Digital, Probation in Court <probation-in-court-team@digital.justice.gov.uk>
 ARG BUILD_NUMBER

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Prepare a case is a service that allows probation staff to prepare court cases.
 
 ## Prerequisities
 Before you begin, ensure you have met the following requirements:
-* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Erbium) >= v12.18.3
+* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Erbium) >= v12.18.4
 
 Or
 
-* You have Node.js (Fermium) >= v14.9.0
+* You have Node.js (Fermium) >= v14.11.0
 
 For code quality the project adheres to [JavaScript Standard Style](https://standardjs.com/) which requires minimal configuration of your chosen IDE.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/ministryofjustice/prepare-a-case.git"
   },
   "engines": {
-    "node": ">=12.18.3 <13.0.0 || >=14.9.0"
+    "node": ">=12.18.4 <13.0.0 || >=14.11.0"
   },
   "scripts": {
     "precommit": "npm run lint && npm run unit-test && npm run mock-validation-test && npm run int-test",


### PR DESCRIPTION
Project now requires the use of Node.js 12.18.4 or 14.11.0 which include important security updates.
Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>