### PR TITLE
PIC-881 View Case List on Sunday

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10551,6 +10551,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "mockdate": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.2.tgz",
+      "integrity": "sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==",
+      "dev": true
+    },
     "module-deps": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "cypress-cucumber-preprocessor": "4.0.0",
     "jest": "26.6.2",
     "jest-junit": "12.0.0",
+    "mockdate": "3.0.2",
     "moxios": "0.4.0",
     "node-sass": "5.0.0",
     "nodemon": "2.0.6",

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const moment = require('moment')
+const getBaseDateString = require('../utils/getBaseDateString')
 const { settings } = require('../../config')
 const { getCaseList, getCase, getMatchDetails, updateCase } = require('../services/case-service')
 const {
@@ -26,14 +26,14 @@ module.exports = function Index ({ authenticationMiddleware }) {
   router.get('/select-court/:selectedCourt?', (req, res) => {
     if (req.params.selectedCourt) {
       res.cookie('court', req.params.selectedCourt).send()
-      res.redirect(`/${req.params.selectedCourt}/cases/${moment().format('YYYY-MM-DD')}`)
+      res.redirect(`/${req.params.selectedCourt}/cases/${getBaseDateString()}`)
     } else {
       res.render('select-court', { title: 'Select court', params: { courtCode: req.cookies.court } })
     }
   })
 
   router.get('/:courtCode/cases', (req, res) => {
-    res.redirect(`/${req.params.courtCode}/cases/${moment().format('YYYY-MM-DD')}${req.session.currentView ? '/' + req.session.currentView : ''}`)
+    res.redirect(`/${req.params.courtCode}/cases/${getBaseDateString()}${req.session.currentView ? '/' + req.session.currentView : ''}`)
   })
 
   router.get('/:courtCode/cases/:date/:subsection?', health, defaults, filters, async (req, res) => {
@@ -77,10 +77,11 @@ module.exports = function Index ({ authenticationMiddleware }) {
     req.session.showAllPreviousOrders = req.params.caseNo
     res.redirect(`/${req.params.courtCode}/case/${req.params.caseNo}/record#previousOrders`)
   })
+
   async function getCaseAndTemplateValues (req) {
     const params = req.params
     const response = await getCase(params.courtCode, params.caseNo)
-    const caseListDate = req.session.caseListDate || moment().format('YYYY-MM-DD')
+    const caseListDate = req.session.caseListDate || getBaseDateString()
     return {
       backLink: req.session.backLink,
       healthy: req.healthy,

--- a/server/utils/getBaseDateString.js
+++ b/server/utils/getBaseDateString.js
@@ -1,0 +1,6 @@
+const moment = require('moment')
+
+module.exports = () => {
+  const tmpMoment = moment()
+  return tmpMoment.day() === 0 ? tmpMoment.add(1, 'days').format('YYYY-MM-DD') : tmpMoment.format('YYYY-MM-DD')
+}

--- a/server/views/case-list.njk
+++ b/server/views/case-list.njk
@@ -91,8 +91,10 @@
     } %}
 {% endif %}
 
+{% set isSunday = moment().day() === 0 %}
 {% set dateFormat = 'dddd D MMMM' %}
 {% set timeStampDateFormat = 'ddd D MMM' %}
+{% set useTodayDate = moment() if not isSunday else moment().add(1, 'days') %}
 {% set currentDate = moment(params.date, 'YYYY-MM-DD') %}
 {% set today = moment().format('YYYY-MM-DD') %}
 {% set tomorrow = moment().add(1, 'days').format('YYYY-MM-DD') %}
@@ -129,7 +131,7 @@
         <span class="govuk-caption-xl">Cases</span>
         {% if params.date === today %}
             Today
-        {% elseif params.date === tomorrow %}
+        {% elseif params.date === tomorrow and not isSunday %}
             Tomorrow
         {% else %}
             {{ currentDate.format(dateFormat) }}
@@ -137,7 +139,7 @@
     </h1>
 
     <p class="govuk-!-margin-bottom-7">
-        {% if currentDate.isAfter(moment()) %}
+        {% if currentDate.isAfter(useTodayDate) %}
             <a class="pac-pagination-link govuk-!-margin-right-5" href="/{{ params.courtCode }}/cases/{{ params.addBusinessDays(currentDate, -1).format('YYYY-MM-DD') }}">
                 <svg class="pac-pagination-link--icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
                     <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>

--- a/tests/routes/view.test.js
+++ b/tests/routes/view.test.js
@@ -1,5 +1,6 @@
 /* global describe, beforeEach, afterEach, it, expect, jest */
 const request = require('supertest')
+const mockDate = require('mockdate')
 const caseService = require('../../server/services/case-service')
 const communityService = require('../../server/services/community-service')
 const appSetup = require('../testUtils/appSetup')
@@ -102,10 +103,23 @@ describe('Routes', () => {
     })
   })
 
-  it('case list route should redirect to corrected route', () => {
+  it('case list route should redirect to corrected route when viewing case list on Sunday', () => {
+    mockDate.set('2020-11-15')
     return request(app).get('/B14LO00/cases').then(response => {
       expect(response.statusCode).toEqual(302)
+      expect(response.headers.location).toBe('/B14LO00/cases/2020-11-16')
       expect(healthcheck.health).not.toHaveBeenCalled()
+      mockDate.reset()
+    })
+  })
+
+  it('case list route should redirect to corrected route', () => {
+    mockDate.set('2020-11-12')
+    return request(app).get('/B14LO00/cases').then(response => {
+      expect(response.statusCode).toEqual(302)
+      expect(response.headers.location).toBe('/B14LO00/cases/2020-11-12')
+      expect(healthcheck.health).not.toHaveBeenCalled()
+      mockDate.reset()
     })
   })
 


### PR DESCRIPTION
:sparkles: Viewing case list on Sunday redirects to Monday
Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>

When viewing the case list on Sunday the application redirects to Monday.
In this case, the page title is changed from "Tomorrow" to "Monday DD MMMM".
Navigating back to case list from case summary functions correctly.
Unit tests include date mock to successfully test.

**N.B.** As this is a Node.js application we cannot mock the date for integration tests, therefore none are written and if the tests are run on a Sunday then we will have failing tests. There doesn't appear to be anything we can do about this.