### PR TITLE
:lipstick: PIC-917: Added whitespace formatting:

### DIFF
--- a/mappings/community/D991494-breach-98765.json
+++ b/mappings/community/D991494-breach-98765.json
@@ -18,7 +18,7 @@
       "team": "Enforcement hub - Sheffield and Rotherham",
       "officer": "Unallocated",
       "status": "Completed - Amended & Continued",
-      "notes": "Paragraph 1: Some information.\nParagraph 2: And some more.",
+      "notes": "Paragraph 1: Some information.\nParagraph 2: And some more.\nParagraph 3: And another\n\nParagraph 4: And another",
       "documents": [
         {
           "documentId": "98765",

--- a/public/stylesheets/app/_white-space-format.scss
+++ b/public/stylesheets/app/_white-space-format.scss
@@ -1,0 +1,3 @@
+.pac-white-space-format {
+  white-space: pre-line;
+}

--- a/public/stylesheets/app/all.scss
+++ b/public/stylesheets/app/all.scss
@@ -9,3 +9,4 @@
 @import "section-break";
 @import "header";
 @import "dashboard-count";
+@import "white-space-format";

--- a/server/views/case-summary-record-order-breach.njk
+++ b/server/views/case-summary-record-order-breach.njk
@@ -77,7 +77,7 @@
 
             <h3 class="govuk-heading-m govuk-!-margin-top-8">Notes</h3>
             {% if breach.notes | length %}
-                <p class="govuk-body">{{ breach.notes }}</p>
+                <p class="govuk-body pac-white-space-format">{{ breach.notes }}</p>
             {% else %}
                 <p class="govuk-body">No notes have been added.</p>
             {% endif %}


### PR DESCRIPTION
Used CSS styling for the white space formatting instead of `<pre>` tags as Cypress `.contains` excludes `<pre>` tags when ignoring invisible whitespaces.

See https://github.com/cypress-io/cypress/pull/5653 for more info
