### PR TITLE
:lipstick: PIC-990: Added properCase filter

### DIFF
--- a/mappings/matching/3597035492-matches.json
+++ b/mappings/matching/3597035492-matches.json
@@ -68,7 +68,7 @@
         },
         {
           "title": "Mr.",
-          "forename": "GUADELOPE",
+          "forename": "GUADALUPE",
           "middleNames": [
             "Flowerlupe"
           ],

--- a/mappings/matching/3597035492-matches.json
+++ b/mappings/matching/3597035492-matches.json
@@ -46,7 +46,7 @@
           "middleNames": [
             "Paul"
           ],
-          "surname": "Hess",
+          "surname": "HESS",
           "dateOfBirth": "1989-02-18",
           "address": {
             "buildingName": "Dunroamin",
@@ -68,7 +68,7 @@
         },
         {
           "title": "Mr.",
-          "forename": "Guadalupe",
+          "forename": "GUADELOPE",
           "middleNames": [
             "Flowerlupe"
           ],

--- a/server/views/match-defendant.njk
+++ b/server/views/match-defendant.njk
@@ -127,7 +127,7 @@
                                             <th scope="row" class="govuk-table__header" style="width: 40%;">Name</th>
                                             <td class="govuk-table__cell">
                                                 {% set matchName = item.forename + ' ' + (item.middleNames | join(' ') + ' ' if item.middleNames) + item.surname %}
-                                                {{ matchName | markMatches(defendantName) | safe }}
+                                                {{ matchName | properCase | markMatches(defendantName) | safe }}
                                             </td>
                                         </tr>
                                         <tr class="govuk-table__row">


### PR DESCRIPTION
- Small change, noticed in sprint planning that the matched defendant names were displaying with incorrect capitalisation as missing `properCase` nunjucks filter, so added that.
- Also updated the mock data to reflect real data