### PR TITLE
BUGFIX Issue with relative links and change to court name

### DIFF
--- a/config.js
+++ b/config.js
@@ -28,7 +28,7 @@ module.exports = {
       { code: 'B14ET', name: 'Doncaster Magistrates\' Court' },
       { code: 'B01GU', name: 'Highbury Corner Magistrates\' Court' },
       { code: 'B16HE', name: 'Hull Magistrates\' Court' },
-      { code: 'B10BD', name: 'Mid and South East Northumberland Magistrates\' Court (aka Bedlington)' },
+      { code: 'B10BD', name: 'Mid and South East Northumberland Magistrates\' Court' },
       { code: 'B10JJ', name: 'Newcastle Magistrates\' Court' },
       { code: 'B10JQ', name: 'North Tyneside Magistrates\' Court' },
       { code: 'B14LO', name: 'Sheffield Magistrates\' Court' }

--- a/integration-tests/integration/features/select-court.feature
+++ b/integration-tests/integration/features/select-court.feature
@@ -15,7 +15,7 @@ Feature: Select court
     And I should see link "Doncaster Magistrates' Court" with href "/select-court/B14ET"
     And I should see link "Highbury Corner Magistrates' Court" with href "/select-court/B01GU"
     And I should see link "Hull Magistrates' Court" with href "/select-court/B16HE"
-    And I should see link "Mid and South East Northumberland Magistrates' Court (aka Bedlington)" with href "/select-court/B10BD"
+    And I should see link "Mid and South East Northumberland Magistrates' Court" with href "/select-court/B10BD"
     And I should see link "Newcastle Magistrates' Court" with href "/select-court/B10JJ"
     And I should see link "North Tyneside Magistrates' Court" with href "/select-court/B10JQ"
     And I should see link "Sheffield Magistrates' Court" with href "/select-court/B14LO"

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -18,6 +18,15 @@ module.exports = function Index ({ authenticationMiddleware }) {
   const router = express.Router()
   router.use(authenticationMiddleware())
 
+  router.use((req, res, next) => {
+    if (req.path.substr(-1) === '/' && req.path.length > 1) {
+      const query = req.url.slice(req.path.length)
+      res.redirect(301, req.path.slice(0, -1) + query)
+    } else {
+      next()
+    }
+  })
+
   router.get('/', health, (req, res) => {
     res.redirect(req.cookies && req.cookies.court ? `/${req.cookies.court}/cases` : '/select-court')
   })

--- a/tests/routes/view.test.js
+++ b/tests/routes/view.test.js
@@ -103,6 +103,13 @@ describe('Routes', () => {
     })
   })
 
+  it('should remove trailing slash from route (and preserve any querystring) in order to permit the use of relative links', () => {
+    return request(app).get('/B14LO/cases/2020-11-12/?page=1').then(response => {
+      expect(response.statusCode).toEqual(301)
+      expect(response.headers.location).toBe('/B14LO/cases/2020-11-12?page=1')
+    })
+  })
+
   it('case list route should redirect to corrected route when viewing case list on Sunday', () => {
     mockDate.set('2020-11-15')
     return request(app).get('/B14LO/cases').then(response => {


### PR DESCRIPTION
:adhesive_bandage: Strip trailing slash to make sure all links can be relative (and preserve any querystring)
:speech_balloon: Fixed incorrect court name

Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>