### PR TITLE
Upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,9 +1569,9 @@
       }
     },
     "@ministryofjustice/frontend": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.0.21.tgz",
-      "integrity": "sha512-yxqPJbRuDJWykeXp9L7+YcngIcdOj+Lav+V7RQY5UUhj8QxP2zPCrN7M+tRbTqXjztyQ5744kv6BU0jNlEAFWQ==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.0.22.tgz",
+      "integrity": "sha512-ywOxscbxFxjarrOUcDhEJ5WH4ebL1sGG8usH5HquFTTS5cpf0EwbBm1uUjzE9yOcVSl7VS2RmNNUfK8Ycgq0Zg==",
       "requires": {
         "moment": "^2.27.0"
       }
@@ -6475,9 +6475,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.1.tgz",
-      "integrity": "sha512-2x6B0jV1pTx4Alxm3MY222BfIQpg+ctUYaUzyBjmNkisWKdRmCP61oyFXklZgqXMjvaN+oo3rRbAALrxFTeeig=="
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.2.tgz",
+      "integrity": "sha512-MpMymgLsKoMw40MggZ0XLCAj1FY5N2s8Pf3aQR+k0cZOsegjLsnejxNfEB9qEl9jcma2fiiVcvsEZ+Ipo+Oo2g=="
     },
     "graceful-fs": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "stepDefinitions": "integration-tests/integration/"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "0.0.21",
+    "@ministryofjustice/frontend": "0.0.22",
     "agentkeepalive": "4.1.3",
     "applicationinsights": "1.8.8",
     "applicationinsights-native-metrics": "0.0.5",
@@ -83,7 +83,7 @@
     "express": "4.17.1",
     "express-request-id": "1.4.1",
     "express-session": "1.17.1",
-    "govuk-frontend": "3.10.1",
+    "govuk-frontend": "3.10.2",
     "helmet": "4.2.0",
     "jsonwebtoken": "8.5.1",
     "jwt-decode": "3.1.2",


### PR DESCRIPTION
:arrow_up: Upgrade MOJ Frontend to 0.0.22
:arrow_up: Upgrade GOVUK Frontend to 3.10.2

Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>