### PR TITLE
PIC-1007 Day Navigation Issue

### DIFF
--- a/server/views/case-list.njk
+++ b/server/views/case-list.njk
@@ -150,6 +150,7 @@
         {%- from "components/days-navigation/macro.njk" import pacDaysNavigation -%}
         {% set totalDays = (params.totalDays - 1) if isSunday else params.totalDays %}
         {{ pacDaysNavigation({
+            baseUrl:  '/' + params.courtCode + '/cases',
             addBusinessDays: params.addBusinessDays,
             totalDays: totalDays,
             startDate: useTodayDate,

--- a/server/views/components/days-navigation/template.njk
+++ b/server/views/components/days-navigation/template.njk
@@ -2,7 +2,7 @@
     {% for days in range(0, params.totalDays) %}
         {%- set thisDate = params.addBusinessDays(params.startDate, days) -%}
         {%- set isCurrentDate = params.currentDate.isSame(thisDate.format('yyyy-MM-DD')) -%}
-        <{{ "span" if isCurrentDate else "a" }} class="pac-days-navigation-item{{ " pac-days-navigation-item__link" if not isCurrentDate }}"{% if not isCurrentDate %} href="{{ thisDate.format('yyyy-MM-DD') }}"{% endif %}>
+        <{{ "span" if isCurrentDate else "a" }} class="pac-days-navigation-item{{ " pac-days-navigation-item__link" if not isCurrentDate }}"{% if not isCurrentDate %} href="{{ params.baseUrl + '/' + thisDate.format('yyyy-MM-DD') }}"{% endif %}>
 
             <span>{{ thisDate.format('ddd') }} </span>
             <span class="govuk-!-font-size-24 govuk-!-font-weight-bold">{{ thisDate.format('D') }}</span>


### PR DESCRIPTION
Day navigation was configured to use relative URLs but this causes an issue if you navigate to the **Recently added** or **Recently removed** tabs on the case list view.

I have implemented a _baseUrl_ value which is passed to the day navigation component in order to correct the URL.


:bug: Fixed issue with day navigation

Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>