### PR TITLE
DO NOT MERGE - Add link to Pre-Sentence Assessment

### DIFF
--- a/config.js
+++ b/config.js
@@ -43,6 +43,10 @@ module.exports = {
       apiClientId: get('API_CLIENT_ID', 'prepare-a-case-for-court'),
       apiClientSecret: get('API_CLIENT_SECRET', 'clientsecret'),
       role: get('ROLE', 'ROLE_PREPARE_A_CASE')
+    },
+    assessRisksAndNeedsService: {
+      url: get('ARN_SERVICE_URL', 'http://localhost:3001/psr-from-court'),
+      enable: get('ARN_SERVICE_ENABLE', false)
     }
   },
   domain: `${get('INGRESS_URL', `http://localhost:${port}`)}`,

--- a/server/services/assess-risks-and-needs-service.js
+++ b/server/services/assess-risks-and-needs-service.js
@@ -1,0 +1,23 @@
+const { send } = require('./utils/request')
+const config = require('../../config')
+
+const arnConfig = config.apis.assessRisksAndNeedsService
+const isEnabled = (enabledFlag) => enabledFlag === true || enabledFlag === 'true'
+
+const presentenceAssessmentEnabled = isEnabled(arnConfig.enable)
+const arnUrl = presentenceAssessmentEnabled && arnConfig.url
+
+const startPresentenceAssessment = async (courtCode, caseNo, tokens) => {
+  if (!presentenceAssessmentEnabled) throw new Error('Presentence Assessment is not available')
+
+  return await send(
+    `${arnUrl}/${courtCode}/case/${caseNo}`,
+    { },
+    tokens
+  )
+}
+
+module.exports = {
+  startPresentenceAssessment,
+  presentenceAssessmentEnabled
+}

--- a/server/services/utils/request.js
+++ b/server/services/utils/request.js
@@ -34,8 +34,24 @@ const update = async (url, data) => {
   return response
 }
 
+const send = async (url, data, tokens) => {
+  const config = { }
+  if (tokens) {
+    config.headers = { Authorization: `bearer ${tokens}` }
+  }
+
+  let response = {}
+  try {
+    response = await axios.post(url, data, config)
+  } catch (e) {
+    axiosError(e)
+  }
+  return response
+}
+
 module.exports = {
   request,
   requestFile,
-  update
+  update,
+  send
 }

--- a/server/views/components/key-details-bar/template.njk
+++ b/server/views/components/key-details-bar/template.njk
@@ -35,6 +35,17 @@
 
         </div>
 
+        {% if params.showPresentenceAssessmentButton %}
+          <div class="pac-key-details-bar-flex__child pac-key-details-bar-flex__child__right govuk-!-margin-right-0">
+              <form method="post" action="/{{ params.courtCode }}/case/{{ params.caseNo }}/assessment">
+                  <button class="govuk-button govuk-button--secondary pac-key-details-bar__button"
+                          data-module="govuk-button" type="submit">Complete Pre-Sentence Assessment
+                  </button>
+              </form>
+          </div>
+        {% endif %}
+
+
         {% if params.probationStatus == 'No record' %}
             <div class="pac-key-details-bar-flex__child pac-key-details-bar-flex__child__right govuk-!-margin-right-0">
                 <form method="get" action="/{{ params.courtCode }}/match/defendant/{{ params.caseNo }}/manual">

--- a/server/views/partials/case-details.njk
+++ b/server/views/partials/case-details.njk
@@ -51,7 +51,8 @@
         probationStatus: probationStatus,
         numberOfPossibleMatches: data.numberOfPossibleMatches,
         breach: breach,
-        hideUnlinkButton: hideUnlinkButton
+        hideUnlinkButton: hideUnlinkButton,
+        showPresentenceAssessmentButton: showPresentenceAssessmentButton
     }) }}
 
 {% endblock %}


### PR DESCRIPTION
Hi friends,

Back before Christmas, we showed the prepare-a-case service linking across to assess-risks-and-needs to start a pre-sentence assessment. That was real but is was also a five minute bodge job. This PR is not that code :) It's been reworked to isolate the bit that hands off to ARN, to minimise the UI part (because, after all, you probably don't actually want the button we whammed in there), to properly configure it, and also hidden it behind a feature flag.

I entirely appreciate you might not want to merge this PR in its entirely, or even at all. However, it's here if you do, or to at least show in code how to bump across to ARN. 