### PR TITLE
Node Security Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ executors:
     working_directory: ~/app
   builder:
     docker:
-      - image: circleci/node:14.15.3-browsers
+      - image: circleci/node:14.15.4-browsers
     working_directory: ~/app
 
 orbs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.3-alpine3.12
+FROM node:14.15.4-alpine3.12
 
 MAINTAINER MoJ Digital, Probation in Court <probation-in-court-team@digital.justice.gov.uk>
 ARG BUILD_NUMBER

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 MoJ Digital & Technology
+Copyright (c) 2021 MoJ Digital & Technology
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,9 +1569,9 @@
       }
     },
     "@ministryofjustice/frontend": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.1.0.tgz",
-      "integrity": "sha512-tSU5IVpGanH0FD7XpXAgJTn3hCsCpHTVj25/msW4UoBGhGewHxVI+BIEmJMYDWor1K1nL3HRf1EeBsJqDS937A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.2.0.tgz",
+      "integrity": "sha512-qWVSvwijdFRdPhBV+9SWgoG92gQKcIZa1JPj3uQYoesfI+nnwKIaNJVIb1aAfHAvKQLTRvJjGfUuRNPdsdDzZA==",
       "requires": {
         "moment": "^2.27.0"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/ministryofjustice/prepare-a-case.git"
   },
   "engines": {
-    "node": ">=14.15.1 <15.0.0"
+    "node": ">=14.15.4 <15.0.0"
   },
   "scripts": {
     "precommit": "npm run lint && npm run unit-test && npm run int-test",
@@ -69,7 +69,7 @@
     "stepDefinitions": "integration-tests/integration/"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "0.1.0",
+    "@ministryofjustice/frontend": "0.2.0",
     "agentkeepalive": "4.1.3",
     "applicationinsights": "1.8.8",
     "applicationinsights-native-metrics": "0.0.5",


### PR DESCRIPTION
Update Node requirement and use to version 14.15.4
See: https://nodejs.org/en/blog/vulnerability/january-2021-security-releases/

:wrench: Updated Dockerfile to use Node 14.15.4
:hammer: Updated package.json to require Node 14.15.4
:construction_worker: Updated Circle config to use Node 14.15.4
:arrow_up: Updated moj-frontend to 0.2.0
:page_facing_up: Updated year in license

Signed-off-by: Paul Massey <paul.massey@digital.justice.gov.uk>