### PR TITLE
PIC-1086 Blank screen when user role missing or incorrect

### DIFF
--- a/app.js
+++ b/app.js
@@ -164,7 +164,8 @@ module.exports = function createApp ({ signInService, userService }) {
 
   app.get('/autherror', (req, res) => {
     res.status(401)
-    return res.render('autherror', {
+    return res.render('error', {
+      status: 401,
       authURL: authLogoutUrl
     })
   })

--- a/server/routes/middleware/authorisationMiddleware.js
+++ b/server/routes/middleware/authorisationMiddleware.js
@@ -1,25 +1,16 @@
 const jwtDecode = require('jwt-decode')
-const logger = require('../../../log.js')
 const config = require('../../../config')
 
 module.exports = (req, res, next) => {
   // Make sure only users with court admin role can access court app
   if (res.locals && res.locals.user && res.locals.user.token) {
     const roles = jwtDecode(res.locals.user.token).authorities
-    logger.info(roles)
     if (!roles.includes(config.apis.oauth2.role)) {
-      return next(unauthorisedError())
+      return res.redirect('/autherror')
     }
-
     return next()
   }
   // No session: get one created
   req.session.returnTo = req.originalUrl
   return res.redirect('/login')
-}
-
-function unauthorisedError () {
-  const error = new Error('Unauthorised access: required role not present')
-  error.status = 403
-  return error
 }

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -1,8 +1,0 @@
-{% extends "partials/layout.njk" %}
-
-{% set title = "Authorisation Error" %}
-
-{% block content %}
-  <h1 class="govuk-heading-l">Authorisation Error</h1>
-  <p class="govuk-body">You are not authorised to use this application.</p>
-{% endblock %}

--- a/server/views/error.njk
+++ b/server/views/error.njk
@@ -1,10 +1,21 @@
 {% extends "partials/layout.njk" %}
 
-{% set title = "Error" %}
-
 {% block navigation %}{% endblock %}
 
+{% if status === 401  %}
+  {% set title = "Authorisation Error" %}
+{% elseif status === 404 %}
+  {% set title = "Page not found" %}
+{% else %}
+  {% set title = "Error" %}
+{% endif %}
+
 {% block content %}
+  {% if status === 401  %}
+    <h1 class="govuk-heading-l">Authorisation Error</h1>
+    <p class="govuk-body">You are not authorised to use this application.</p>
+  {% endif %}
+
   {% if status === 404  %}
     <h1 class="govuk-heading-l">Page not found</h1>
     <p class="govuk-body">If you entered a web address, check it is correct.</p>
@@ -21,7 +32,12 @@
     <p class="govuk-body">You'll be able to use the service on {{ maintenanceDate }}.</p>
   {% endif %}
 
-  <p class="govuk-body">{{ message }}</p>
-  <p class="govuk-body">{{ stack }}</p>
+  {% if message and message | length %}
+    <p class="govuk-body">{{ message }}</p>
+  {% endif %}
+
+  {% if stack and stack | length %}
+    <p class="govuk-body">{{ stack }}</p>
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
:bug: Fixed issue of blank screen when user role is incorrect
:recycle: Refactored auth middleware
:fire: Removed autherror template
:recycle: Included auth error in main error template
:wheelchair: Updated page title(s) on error page in order to improve a11y

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>