### PR TITLE
Unsupported court code causes front end to crash

### DIFF
--- a/server/routes/middleware/defaults.js
+++ b/server/routes/middleware/defaults.js
@@ -39,7 +39,7 @@ function addBusinessDays (originalDate, daysToAdd) {
 function courtLookup (courtCode) {
   const courtLookup = settings.availableCourts.find(court => court.code === courtCode)
   return {
-    name: courtLookup && courtLookup.name || ''
+    name: (courtLookup && courtLookup.name) || ''
   }
 }
 

--- a/server/routes/middleware/defaults.js
+++ b/server/routes/middleware/defaults.js
@@ -37,8 +37,9 @@ function addBusinessDays (originalDate, daysToAdd) {
 }
 
 function courtLookup (courtCode) {
+  const courtLookup = settings.availableCourts.find(court => court.code === courtCode)
   return {
-    name: settings.availableCourts.find(court => court.code === courtCode).name
+    name: courtLookup && courtLookup.name || ''
   }
 }
 


### PR DESCRIPTION
As the court codes and names are currently hardcoded, changing this code in the URL causes  a crash in the frontend.

This fixes the issue but in these instances, the court name will of course not be displayed.

:bug: Unsupported court code causes front end to crash

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>