### PR TITLE
Node.js February 2021 Security Releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ executors:
     working_directory: ~/app
   builder:
     docker:
-      - image: circleci/node:14.15.4-browsers
+      - image: circleci/node:14.16.0-browsers
     working_directory: ~/app
 
 orbs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.5-alpine3.13
+FROM node:14.16.0-alpine3.13
 
 MAINTAINER MoJ Digital, Probation in Court <probation-in-court-team@digital.justice.gov.uk>
 ARG BUILD_NUMBER

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Prepare a case is a service that allows probation staff to prepare court cases.
 
 ## Prerequisities
 Before you begin, ensure you have met the following requirements:
-* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Fermium) >= v14.15.4
+* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Fermium) >= v14.16.0
 
 For code quality the project adheres to [JavaScript Standard Style](https://standardjs.com/) which requires minimal configuration of your chosen IDE.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3875,9 +3875,9 @@
       }
     },
     "@pact-foundation/pact": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-9.15.0.tgz",
-      "integrity": "sha512-WYisUGpCvxYogvq/XhENdV7RqNFocoOX7JquhRJkGOEQdlrSlongvyjqF2/wwAB1ty2HWC6/YpKFuVjQkS1Mvg==",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-9.15.1.tgz",
+      "integrity": "sha512-GExDqpBYLP0zv0OrucGq010f+9XSxTXm75s/LACdHXyo0wwie4u1s+yfO4TQjv/1Tx8kYMnPMTOUDqcjisr7Gg==",
       "dev": true,
       "requires": {
         "@pact-foundation/pact-node": "^10.11.4",
@@ -3893,7 +3893,7 @@
         "graphql-tag": "^2.9.1",
         "http-proxy": "^1.18.1",
         "http-proxy-middleware": "^0.19.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "lodash.isfunction": "3.0.8",
         "lodash.isnil": "4.0.0",
         "lodash.isundefined": "3.0.1",
@@ -3910,13 +3910,19 @@
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
           "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
           "dev": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
         }
       }
     },
     "@pact-foundation/pact-node": {
-      "version": "10.11.8",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-node/-/pact-node-10.11.8.tgz",
-      "integrity": "sha512-HjCJ9wCerlLDmK9KqkwkfybvhTkO8kmr/fMZIx83tFrc5BSVQRG1ds0mjfDYTkAy7BooMV2dGwtVejLtXnsoxg==",
+      "version": "10.11.9",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-node/-/pact-node-10.11.9.tgz",
+      "integrity": "sha512-/2/0vWKmiuvNwLAaTR6FxRDY3ecfxMGPff1cem9fAg5sN76tuJOU12Ra5//TUIAi1CKAAauGvt/UxrCX6kK65g==",
       "dev": true,
       "requires": {
         "@types/pino": "^6.3.5",
@@ -11003,9 +11009,9 @@
       }
     },
     "jest-pact": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.8.1.tgz",
-      "integrity": "sha512-rYZEj9Z1Gdfv8/71wCoHrQK/ee+uB89u2nFEjlhs21CFHvz8obAMWKOQA6IMxfbT9JrJq54qPfkmVXFPvaZ6gA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/jest-pact/-/jest-pact-0.8.3.tgz",
+      "integrity": "sha512-pg7ve7LeDtJo5Yv6UAeWCapHvw/4Nr0rLv8Sx0mmcDZjWWghSlgMm3q8DCxJRNeETWSpOnNeV6Sgup1m/ivA8Q==",
       "dev": true,
       "requires": {
         "@types/jest": "26.0.10"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/ministryofjustice/prepare-a-case.git"
   },
   "engines": {
-    "node": ">=14.15.4 <15.0.0"
+    "node": ">=14.16.0 <15.0.0"
   },
   "scripts": {
     "precommit": "npm run lint && npm run unit-test && npm run int-test",
@@ -28,7 +28,7 @@
     "css-build": "bash ./bin/build-css",
     "minify-js-css": "bash ./bin/minify-js-css",
     "start": "npm run css-build && npm run minify-js-css && node ./bin/www",
-    "start:watch": "nodemon --exec npm run start --scripts-prepend-node-path",
+    "start:watch": "npx nodemon --exec npm run start --scripts-prepend-node-path",
     "unit-test": "npx jest --config=./tests/jest.config.js --ci --detectOpenHandles --forceExit",
     "pact-test": "rm -rf pact && npx jest --config=./tests/jest.pact.config.js --ci",
     "record-build-info": "node ./bin/record-build-info"
@@ -100,7 +100,7 @@
     "superagent": "6.1.0"
   },
   "devDependencies": {
-    "@pact-foundation/pact": "9.15.0",
+    "@pact-foundation/pact": "9.15.1",
     "axe-core": "4.1.2",
     "cucumber": "6.0.5",
     "cypress": "6.5.0",
@@ -108,7 +108,7 @@
     "cypress-cucumber-preprocessor": "4.0.1",
     "jest": "26.6.3",
     "jest-junit": "12.0.0",
-    "jest-pact": "0.8.1",
+    "jest-pact": "0.8.3",
     "minify": "7.0.1",
     "mockdate": "3.0.2",
     "moxios": "0.4.0",


### PR DESCRIPTION
See: https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/

:construction_worker: Updated CircleCI to use Node 14.16.0
:wrench: Updated project to use Node 14.16.0
:wrench: Updated Dockerfile to use Node 14.16.0
:memo: Updated Readme
:arrow_up: Updated dependencies
:wrench: Updated start:watch command to use npx

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>