### PR TITLE
:adhesive_bandage: PIC-1173: added cookie-session

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,11 +4,9 @@ const config = require('./config')
 const express = require('express')
 const compression = require('compression')
 const cookieParser = require('cookie-parser')
-const session = require('express-session')
+const cookieSession = require('cookie-session')
 const helmet = require('helmet')
 const path = require('path')
-const MemoryStore = require('memorystore')(session)
-const sessionExpiry = config.session.expiry * 60 * 1000
 const passport = require('passport')
 const createRouter = require('./server/routes')
 const createAttachmentsRouter = require('./server/routes/attachments')
@@ -48,15 +46,17 @@ module.exports = function createApp ({ signInService, userService }) {
   }))
 
   app.use(compression())
-  app.use(session({
-    cookie: { maxAge: sessionExpiry },
-    store: new MemoryStore({
-      checkPeriod: sessionExpiry
-    }),
-    secret: config.session.secret,
-    resave: true,
-    saveUninitialized: true
-  }))
+  app.use(
+    cookieSession({
+      name: 'session',
+      keys: [config.session.secret],
+      maxAge: 60 * 60 * 1000,
+      secure: config.https,
+      httpOnly: true,
+      signed: true,
+      overwrite: true,
+      sameSite: 'lax'
+    }))
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
   app.use(cookieParser())

--- a/config.js
+++ b/config.js
@@ -38,8 +38,7 @@ module.exports = {
     ]
   },
   session: {
-    secret: get('SESSION_SECRET', 'prepare-a-case-insecure-default-session'),
-    expiry: get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)
+    secret: get('SESSION_SECRET', 'prepare-a-case-insecure-default-session')
   },
   apis: {
     courtCaseService: {


### PR DESCRIPTION
Replaced express-session with cookie-session due to issues with express-session memory store capability of keeping the session info in memory in one of the pods. If another request comes in and hits another pod then it won't find the session and will consider the user logged out / or have to have an invalid session. This is causing issues for us when we increase the amount of pods.