### PR TITLE
PIC-1096 Probation Status

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -273,7 +273,7 @@ module.exports = function Index ({ authenticationMiddleware }) {
       pnc: crn ? offenderDetail.otherIds.pncNumber : caseResponse.pnc,
       crn: crn ? offenderDetail.otherIds.crn : null,
       cro: crn ? offenderDetail.otherIds.croNumber : null,
-      probationStatus: crn ? offenderDetail.probationStatus : 'No record'
+      probationStatus: crn ? offenderDetail.probationStatus : null
     })
   }
 


### PR DESCRIPTION
As per discussion with Chris, we need to change the probation status to null when unlinking a defendant

:bug: Fixed probation status when unmatching defendant

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>