### PR TITLE
Node security release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,15 +60,15 @@ commands:
 executors:
   deployer:
     docker:
-      - image: circleci/python:3
+      - image: cimg/python:3.9.2
     working_directory: ~/app
   builder:
     docker:
-      - image: circleci/node:14.16.0-browsers
+      - image: cimg/node:14.16.1-browsers
     working_directory: ~/app
   integration-tests:
     docker:
-      - image: circleci/node:14.16.0-browsers
+      - image: cimg/node:14.16.1-browsers
       - image: bitnami/redis:5.0
         environment:
           ALLOW_EMPTY_PASSWORD=yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.0-alpine3.13
+FROM node:14.16.1-alpine3.13
 
 MAINTAINER MoJ Digital, Probation in Court <probation-in-court-team@digital.justice.gov.uk>
 ARG BUILD_NUMBER

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Prepare a case is a service that allows probation staff to prepare court cases.
 
 ## Prerequisities
 Before you begin, ensure you have met the following requirements:
-* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Fermium) >= v14.16.0
+* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Fermium) >= v14.16.1
 
 For code quality the project adheres to [JavaScript Standard Style](https://standardjs.com/) which requires minimal configuration of your chosen IDE.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prepare-a-case",
-  "version": "0.0.1",
+  "version": "1.0.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1010,35 +1010,34 @@
       }
     },
     "@cucumber/create-meta": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@cucumber/create-meta/-/create-meta-2.0.4.tgz",
-      "integrity": "sha512-upbfuih3NVm1efWSbPGH7HI6O2O037QRAPLMgTDIGaf2lfcrMCgB/qkqPHk8DOUuz7Vjpg5tFFoJODSDcxtNOA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/create-meta/-/create-meta-4.0.0.tgz",
+      "integrity": "sha512-I2GWC9PoIGmpc0w/vz2YYeGl/eog1oFogYKUjgflDjhECo1mpD/WQjMRPNOsZnd859S8fPgVByKzGQAWjfjGyQ==",
       "dev": true,
       "requires": {
-        "@cucumber/messages": "^13.1.0",
-        "ts-node": "^9.0.0",
-        "typescript": "^4.0.5"
+        "@cucumber/messages": "^15.0.0"
       }
     },
     "@cucumber/cucumber": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-7.0.0.tgz",
-      "integrity": "sha512-A2SmINqVy9MG8qjF7W7Nqn0rPYJWIBypcTAMiH0e4K8ZEDO5sJNQrv9uOBatAfwqHwK5Si0tUYmH6OnzQse9nQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-7.1.0.tgz",
+      "integrity": "sha512-ZeXXHzpcDULZMd+Og/Le9t+pt/FEepNoEDx66rbfFAiVGDQieljF5/Ag8qifRqKLLT3EE/Mu5HQ3oT1Rk8V5Gw==",
       "dev": true,
       "requires": {
-        "@cucumber/create-meta": "^2.0.4",
-        "@cucumber/cucumber-expressions": "^11.0.0",
-        "@cucumber/gherkin": "^16.0.0",
-        "@cucumber/html-formatter": "^11.0.4",
-        "@cucumber/messages": "^13.2.1",
-        "@cucumber/query": "^7.0.1",
-        "@cucumber/tag-expressions": "^2.0.4",
-        "assertion-error-formatter": "^3.0.0",
+        "@cucumber/create-meta": "4.0.0",
+        "@cucumber/cucumber-expressions": "12.0.1",
+        "@cucumber/gherkin": "18.0.0",
+        "@cucumber/gherkin-streams": "1.0.0",
+        "@cucumber/html-formatter": "13.0.0",
+        "@cucumber/messages": "15.0.0",
+        "@cucumber/query": "9.0.2",
+        "@cucumber/tag-expressions": "3.0.1",
+        "assertion-error-formatter": "3.0.0",
         "bluebird": "^3.7.2",
         "capital-case": "^1.0.4",
         "cli-table3": "^0.6.0",
         "colors": "^1.4.0",
-        "commander": "^6.2.1",
+        "commander": "^7.0.0",
         "create-require": "^1.1.1",
         "duration": "^0.2.2",
         "durations": "^3.4.2",
@@ -1048,7 +1047,7 @@
         "is-generator": "^1.0.3",
         "is-stream": "^2.0.0",
         "knuth-shuffle-seeded": "^1.0.6",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
         "resolve": "^1.19.0",
@@ -1062,9 +1061,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         },
         "stack-chain": {
@@ -1076,116 +1075,100 @@
       }
     },
     "@cucumber/cucumber-expressions": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-11.0.2.tgz",
-      "integrity": "sha512-QFbRzXLMBFmMfxlheus6pCLijyWzN00mdCXGPmqvSPQfvluHvV4748MrALSxVvXYT2oCfl/VwIqbN/baWy4JNQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-12.0.1.tgz",
+      "integrity": "sha512-ANzu80Mw9GzTQ5ImuLdBtHnQfG8MghVvvtud4GHBvlQ4Wzu1SvkUj3RsdtW9w3p7mATSw8SiSFj6Jel3cEWN6Q==",
       "dev": true,
       "requires": {
         "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.4.0"
       }
     },
     "@cucumber/gherkin": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-16.0.0.tgz",
-      "integrity": "sha512-DBX+cEnvIjnmKR8IQrZiea+7cgOLUTB+E8llnM2PEMMUNIn1FKhcDoPkiZ+3wMj4U6eNtiK0fr+9Hvwg+g+28g==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-18.0.0.tgz",
+      "integrity": "sha512-Az+VD2NyOM2ZjzuVGrpJTl1VDv1j50graLtjUp7GfGYN+wMMV+jPgKV5fGYQeocjDnJYYlKymiUZzxcxvStJmg==",
       "dev": true,
       "requires": {
-        "@cucumber/messages": "^13.2.1",
-        "commander": "^6.2.0",
+        "@cucumber/message-streams": "^1.0.0",
+        "@cucumber/messages": "^15.0.0"
+      }
+    },
+    "@cucumber/gherkin-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-streams/-/gherkin-streams-1.0.0.tgz",
+      "integrity": "sha512-ZGUvkwj8DnMozii+8YqWtiWuKqU+Opt50dWVeJzv2e+4GDh0P1Nc04RGMZkFf8WTl2sgBJq5waPUKCQVPaw6iQ==",
+      "dev": true,
+      "requires": {
+        "@cucumber/gherkin": "^18.0.0",
+        "@cucumber/message-streams": "^1.0.0",
+        "@cucumber/messages": "^15.0.0",
+        "commander": "^7.2.0",
+        "protobufjs": "^6.10.2",
         "source-map-support": "^0.5.19"
       },
       "dependencies": {
         "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         }
-      }
-    },
-    "@cucumber/gherkin-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-2.1.1.tgz",
-      "integrity": "sha512-3wSvFMi6i8lCxNIOM+WMWh/kvnUCEc1S7e0qUlEV7SaW/I4HqXwAodcZjoP6LBkwbPRpK+xEzqitsVLq0x88jQ==",
-      "dev": true,
-      "requires": {
-        "@cucumber/messages": "^13.2.1",
-        "@teppeis/multimaps": "^1.1.0"
       }
     },
     "@cucumber/html-formatter": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-11.0.4.tgz",
-      "integrity": "sha512-Ojsx8U6C5IMLpQRYHugan2XM0/+5qXSCrds2Z7/bySuoaZr6ppVYB2jb03aXKWKA4GaMVbflpFOajb4Bc3niUg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-13.0.0.tgz",
+      "integrity": "sha512-+gNLbgeti/5UXm2bVYvtjgdlEiY6r1WsNWChezXE6LJsviy7HrA6WWbwFWFSxs3CLgee5Us5Pe8JonQAnFEiBw==",
       "dev": true,
       "requires": {
-        "@cucumber/gherkin-utils": "^2.1.1",
-        "@cucumber/messages": "^13.2.1",
-        "@cucumber/query": "^7.0.1",
-        "@cucumber/react": "^11.0.2",
-        "commander": "^6.2.1",
-        "react": "^17.0.1",
-        "react-dom": "^17.0.1",
-        "resolve-pkg": "^2.0.0",
+        "@cucumber/messages": "^15.0.0",
+        "commander": "^7.2.0",
         "source-map-support": "^0.5.19"
       },
       "dependencies": {
         "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         }
       }
     },
+    "@cucumber/message-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/message-streams/-/message-streams-1.0.0.tgz",
+      "integrity": "sha512-i1Jx0EDnE+3Na82UxJ2VqE6aWWJJ+1H+3ax+SYgHmCmlUDJiJzx9dHxAAO3GISrM/RYUAuqMGHNAMnIcxkL3Pw==",
+      "dev": true,
+      "requires": {
+        "@cucumber/messages": "^15.0.0",
+        "protobufjs": "^6.10.2"
+      }
+    },
     "@cucumber/messages": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-13.2.1.tgz",
-      "integrity": "sha512-2cu6P1JsEcH0/RlMx302KOK9rkKDHYS1H+6/VhQ6L+yrVW458wOU3CiVgurLn3heCDdJH8r4L87pkSwt0rxiGQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-15.0.0.tgz",
+      "integrity": "sha512-LtxzSCRmYZTAKO6ucAcMflz0u90l2fev539OG+EioJ26F14KmmtxZwGabfjTxLf8NgyKeWsO8TGI2G3z4Kjr+A==",
       "dev": true,
       "requires": {
         "@types/uuid": "^8.3.0",
         "protobufjs": "^6.10.2",
-        "uuid": "^8.3.1"
+        "uuid": "^8.3.2"
       }
     },
     "@cucumber/query": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-7.0.1.tgz",
-      "integrity": "sha512-Ocxtm0LLLbYa3TwZZFzHG4/uHnb7GkYNUsRzf+bLyKOYymkffMkgLcITkx+X4Kw/tq+xzzHh3z/YivEAXxBJdQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-9.0.2.tgz",
+      "integrity": "sha512-YrOSZQzWWVle+8B57zaSFfQt9jYTPDamBnwdc1EGKI1sXyALjHnGgCLXUFH/HjDieQkXIh2y+MHJ51t2u9ys1A==",
       "dev": true,
       "requires": {
-        "@cucumber/messages": "^13.2.1",
-        "@teppeis/multimaps": "^1.1.0"
-      }
-    },
-    "@cucumber/react": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@cucumber/react/-/react-11.0.2.tgz",
-      "integrity": "sha512-kT3T2zakMI9JDOHGpCxFgq54T/xkGFIvbEKm6vRjW5WjbDXV7pp5sMsxqeL5TS9MgmNRkZ3gNr1hX7MKytWb9g==",
-      "dev": true,
-      "requires": {
-        "@cucumber/gherkin-utils": "^2.1.1",
-        "@cucumber/messages": "^13.2.1",
-        "@cucumber/query": "^7.0.1",
-        "@cucumber/tag-expressions": "^2.0.4",
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
-        "@fortawesome/free-solid-svg-icons": "^5.15.1",
-        "@fortawesome/react-fontawesome": "^0.1.13",
-        "@teppeis/multimaps": "^1.1.0",
-        "@types/elasticlunr": "^0.9.1",
-        "ansi-to-html": "^0.6.14",
-        "color": "^3.1.3",
-        "elasticlunr": "^0.9.5",
-        "highlight-words": "^1.0.6",
-        "react-accessible-accordion": "^3.3.3",
-        "react-markdown": "^5.0.3"
+        "@cucumber/messages": "^15.0.0",
+        "@teppeis/multimaps": "^2.0.0"
       }
     },
     "@cucumber/tag-expressions": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-2.0.4.tgz",
-      "integrity": "sha512-HiNncmg/gS34yNpMFAeoIyUHqLFFN92MXIj3rs+BKo7vn16SxvYsigDvd2PAHyjSIThsp9TO1XDtl0SLKVB58g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-3.0.1.tgz",
+      "integrity": "sha512-OGCXaJ1BQXmQ5b9pw+JYsBGumK2/LPZiLmbj1o1JFVeSNs2PY8WPQFSyXrskhrHz5Nd/6lYg7lvGMtFHOncC4w==",
       "dev": true
     },
     "@cypress/browserify-preprocessor": {
@@ -1409,39 +1392,6 @@
             "type-fest": "^0.8.1"
           }
         }
-      }
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.35",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
-      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==",
-      "dev": true
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.35",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
-      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
-      "dev": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "5.15.3",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
-      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
-      "dev": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
-      "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.7.2"
       }
     },
     "@hapi/bourne": {
@@ -2364,9 +2314,9 @@
       }
     },
     "@teppeis/multimaps": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-1.1.0.tgz",
-      "integrity": "sha512-YgANgfYU7LqgaLkGPWSTiwu2qcuhj0IOvj+kRwDFjAVbiEXT7ZQLPaFfmrAAN/Fa+tvwy1aYFd0RdT7lMO1Msw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-2.0.0.tgz",
+      "integrity": "sha512-TL1adzq1HdxUf9WYduLcQ/DNGYiz71U31QRgbnr0Ef1cPyOUOsBojxHVWpFeOSUucB6Lrs0LxFRA14ntgtkc9w==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -2445,12 +2395,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/elasticlunr": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@types/elasticlunr/-/elasticlunr-0.9.1.tgz",
-      "integrity": "sha512-FOS+tbeQKVIq8HAQ5WkWXMPIEeLFJViIMnWfLsxtRKX0jtWSM+emZe43+sKZgwny7EIfVdbbqdtr+RL2h18ykw==",
-      "dev": true
     },
     "@types/express": {
       "version": "4.17.11",
@@ -2645,15 +2589,6 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
       "dev": true
     },
-    "@types/mdast": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "*"
-      }
-    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -2782,12 +2717,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
-      "dev": true
-    },
-    "@types/unist": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
     },
     "@types/uuid": {
@@ -3012,15 +2941,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "ansi-to-html": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.14.tgz",
-      "integrity": "sha512-7ZslfB1+EnFSDO5Ju+ue5Y6It19DRnZXWv8jrGHgIlPna5Mh4jz7BV5jCbQneXNFurQcKoolaaAjHtgSBfOIuA==",
-      "dev": true,
-      "requires": {
-        "entities": "^1.1.2"
-      }
-    },
     "ansicolors": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
@@ -3092,12 +3012,6 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -3371,9 +3285,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz",
-      "integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.4.tgz",
+      "integrity": "sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==",
       "dev": true
     },
     "axios": {
@@ -3551,12 +3465,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
       "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
-      "dev": true
-    },
-    "bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
       "dev": true
     },
     "balanced-match": {
@@ -4386,24 +4294,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "character-entities": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true
-    },
-    "character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true
-    },
-    "character-reference-invalid": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -4752,16 +4642,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-      "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -4776,16 +4656,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "color-string": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "colorette": {
       "version": "1.2.2",
@@ -5150,11 +5020,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
-    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -5255,19 +5120,19 @@
       }
     },
     "cypress": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.8.0.tgz",
-      "integrity": "sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.0.0.tgz",
+      "integrity": "sha512-gri53gIGQPf/RoUknwvNS3alUjZwdmtp9BcKzLgyrwA/gBxJcpDLZ1t+MTvXy57ifRWEMxmEWzQe+iszCzJZqA==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
         "@cypress/request": "^2.88.5",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "12.12.50",
-        "@types/sinonjs__fake-timers": "^6.0.1",
+        "@types/node": "^14.14.31",
+        "@types/sinonjs__fake-timers": "^6.0.2",
         "@types/sizzle": "^2.3.2",
-        "arch": "^2.1.2",
-        "blob-util": "2.0.2",
+        "arch": "^2.2.0",
+        "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
@@ -5275,27 +5140,26 @@
         "cli-table3": "~0.6.0",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
-        "dayjs": "^1.9.3",
+        "dayjs": "^1.10.4",
         "debug": "4.3.2",
-        "eventemitter2": "^6.4.2",
-        "execa": "^4.0.2",
+        "eventemitter2": "^6.4.3",
+        "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "^1.7.0",
-        "fs-extra": "^9.0.1",
+        "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.3.2",
+        "is-ci": "^3.0.0",
+        "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr": "^0.14.3",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.5",
-        "moment": "^2.29.1",
         "ospath": "^1.2.2",
-        "pretty-bytes": "^5.4.1",
+        "pretty-bytes": "^5.6.0",
         "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
-        "supports-color": "^7.2.0",
+        "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "url": "^0.11.0",
@@ -5303,9 +5167,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.50",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
-          "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
+          "version": "14.14.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+          "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
           "dev": true
         },
         "ansi-styles": {
@@ -5325,7 +5189,24 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
           }
+        },
+        "ci-info": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.1.1.tgz",
+          "integrity": "sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==",
+          "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
@@ -5351,16 +5232,50 @@
             "ms": "2.1.2"
           }
         },
+        "global-dirs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+          "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+          "dev": true,
+          "requires": {
+            "ini": "2.0.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "ini": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
+          "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^3.1.1"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+          "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+          "dev": true,
+          "requires": {
+            "global-dirs": "^3.0.0",
+            "is-path-inside": "^3.0.2"
+          }
+        },
         "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -5823,44 +5738,10 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-serializer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-      "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.1.0"
-          }
-        },
-        "entities": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-          "dev": true
-        }
-      }
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "domelementtype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
       "dev": true
     },
     "domexception": {
@@ -5877,37 +5758,6 @@
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
-        }
-      }
-    },
-    "domhandler": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1"
-      }
-    },
-    "domutils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
-      "integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.1.0"
-          }
         }
       }
     },
@@ -5998,12 +5848,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "elasticlunr": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/elasticlunr/-/elasticlunr-0.9.5.tgz",
-      "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU=",
-      "dev": true
-    },
     "electron-to-chromium": {
       "version": "1.3.698",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.698.tgz",
@@ -6081,12 +5925,6 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
-    },
-    "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
     },
     "env-paths": {
       "version": "2.2.1",
@@ -7988,12 +7826,6 @@
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.4.1.tgz",
       "integrity": "sha512-G8tp0wUMI7i8wkMk2xLcEvESg5PiCitFMYgGRc/PwULB0RVhTP5GFdxOwvJwp9XVha8CuS8mnhmE8I/8dx/pbw=="
     },
-    "highlight-words": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/highlight-words/-/highlight-words-1.1.0.tgz",
-      "integrity": "sha512-Os+PywBpfT5LZsKM5UJowY34i28aVKIt+iqfg2Muj7uXS3i92FW4nRYQwoy0r/XrYQf3icK6k8uqC0f5V3IEhQ==",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -8077,43 +7909,11 @@
         }
       }
     },
-    "html-to-react": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.5.tgz",
-      "integrity": "sha512-KONZUDFPg5OodWaQu2ymfkDmU0JA7zB1iPfvyHehTmMUZnk0DS7/TyCMTzsLH6b4BvxX15g88qZCXFhJWktsmA==",
-      "dev": true,
-      "requires": {
-        "domhandler": "^3.3.0",
-        "htmlparser2": "^5.0",
-        "lodash.camelcase": "^4.3.0",
-        "ramda": "^0.27.1"
-      }
-    },
     "htmlescape": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
-    },
-    "htmlparser2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0",
-        "domutils": "^2.4.2",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-          "dev": true
-        }
-      }
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -8389,28 +8189,6 @@
         }
       }
     },
-    "is-alphabetical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true
-    },
-    "is-alphanumerical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "dev": true,
-      "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      }
-    },
-    "is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "dev": true
-    },
     "is-bigint": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
@@ -8434,12 +8212,6 @@
       "requires": {
         "call-bind": "^1.0.0"
       }
-    },
-    "is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true
     },
     "is-callable": {
       "version": "1.2.3",
@@ -8495,12 +8267,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
-    },
-    "is-decimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
     },
     "is-descriptor": {
@@ -8582,12 +8348,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-hexadecimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true
-    },
     "is-installed-globally": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
@@ -8661,12 +8421,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true
-    },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
     "is-plain-object": {
@@ -10978,12 +10732,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -11308,34 +11056,6 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "mdast-add-list-metadata": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
-      "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
-      "dev": true,
-      "requires": {
-        "unist-util-visit-parents": "1.1.2"
-      }
-    },
-    "mdast-util-from-markdown": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-      "dev": true,
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "micromark": "~2.11.0",
-        "parse-entities": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      }
-    },
-    "mdast-util-to-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-      "dev": true
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -11440,16 +11160,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "micromark": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.0.0",
-        "parse-entities": "^2.0.0"
-      }
     },
     "micromatch": {
       "version": "3.1.10",
@@ -12564,20 +12274,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "dev": true,
-      "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -13320,64 +13016,11 @@
         }
       }
     },
-    "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "react-accessible-accordion": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/react-accessible-accordion/-/react-accessible-accordion-3.3.4.tgz",
-      "integrity": "sha512-EUq+KmVRIIG5u1fR5XIbb2JU7w7NouLjuyfuPvnhuDIfNNWNYap1I8ijn2rdA6OQi1gGSRGbVzHs+3wxH/M0Sw==",
-      "dev": true
-    },
-    "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "react-markdown": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
-      "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
-      "dev": true,
-      "requires": {
-        "@types/mdast": "^3.0.3",
-        "@types/unist": "^2.0.3",
-        "html-to-react": "^1.3.4",
-        "mdast-add-list-metadata": "1.0.1",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.6",
-        "remark-parse": "^9.0.0",
-        "unified": "^9.0.0",
-        "unist-util-visit": "^2.0.0",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-          "dev": true
-        }
-      }
     },
     "read-only-stream": {
       "version": "2.0.0",
@@ -13670,15 +13313,6 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
-    "remark-parse": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-      "dev": true,
-      "requires": {
-        "mdast-util-from-markdown": "^0.8.0"
-      }
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -13907,9 +13541,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.6.tgz",
-      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -14160,16 +13794,6 @@
         "xmlchars": "^2.2.0"
       }
     },
-    "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -14399,15 +14023,6 @@
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -15562,12 +15177,6 @@
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
-    "trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
-    },
     "true-case-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
@@ -15582,20 +15191,6 @@
       "resolved": "https://registry.npmjs.org/try-to-catch/-/try-to-catch-3.0.0.tgz",
       "integrity": "sha512-eIm6ZXwR35jVF8By/HdbbkcaCDTBI5PpCPkejRKrYp0jyf/DbCCcRhHD7/O9jtFI3ewsqo9WctFEiJTS6i+CQA==",
       "dev": true
-    },
-    "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dev": true,
-      "requires": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      }
     },
     "tsconfig-paths": {
       "version": "3.9.0",
@@ -15709,12 +15304,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
-      "dev": true
-    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -15827,20 +15416,6 @@
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
     },
-    "unified": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
-      "integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
-      "dev": true,
-      "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-buffer": "^2.0.0",
-        "is-plain-obj": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -15861,50 +15436,6 @@
       "requires": {
         "crypto-random-string": "^2.0.0"
       }
-    },
-    "unist-util-is": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "dev": true
-    },
-    "unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.2"
-      }
-    },
-    "unist-util-visit": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-is": "^4.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "dependencies": {
-        "unist-util-visit-parents": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-          "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "unist-util-is": "^4.0.0"
-          }
-        }
-      }
-    },
-    "unist-util-visit-parents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
-      "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==",
-      "dev": true
     },
     "universalify": {
       "version": "2.0.0",
@@ -16233,28 +15764,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "vfile": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      }
-    },
-    "vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vm-browserify": {
@@ -16665,12 +16174,6 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prepare-a-case",
-  "version": "0.0.1",
+  "version": "1.0.0-beta",
   "description": "A service to allow probation staff to prepare court cases",
   "author": "MoJ D&T Probation in Court <probation-in-court-team@digital.justice.gov.uk>",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "url": "https://github.com/ministryofjustice/prepare-a-case.git"
   },
   "engines": {
-    "node": ">=14.16.0 <15.0.0"
+    "node": ">=14.16.1 <15.0.0"
   },
   "scripts": {
     "precommit": "npm run lint && npm run unit-test && npm run int-test",
@@ -82,7 +82,6 @@
     "connect-redis": "5.1.0",
     "cookie-parser": "1.4.5",
     "cookie-session": "1.4.0",
-    "crypto": "1.0.1",
     "csurf": "1.11.0",
     "debug": "4.3.1",
     "dotenv": "8.2.0",
@@ -102,10 +101,10 @@
     "superagent": "6.1.0"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "7.0.0",
+    "@cucumber/cucumber": "7.1.0",
     "@pact-foundation/pact": "9.15.4",
-    "axe-core": "4.1.3",
-    "cypress": "6.8.0",
+    "axe-core": "4.1.4",
+    "cypress": "7.0.0",
     "cypress-axe": "0.12.2",
     "cypress-cucumber-preprocessor": "4.0.3",
     "jest": "26.6.3",


### PR DESCRIPTION
Update requirement for Node.js April 2021 Security Release.
Updated to use new next-gen CircleCi convenience Docker images.

See https://nodejs.org/en/blog/vulnerability/april-2021-security-releases/