### PR TITLE
Rename court cookie

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -33,7 +33,11 @@ module.exports = function Index ({ authenticationMiddleware }) {
 
   router.get('/', (req, res) => {
     const { cookies } = req
-    res.redirect(302, cookies && cookies.court ? `/${cookies.court}/cases` : '/my-courts/setup')
+    // @FIXME: Cookie check and removal to be removed at a later date
+    if (cookies && cookies.court) {
+      res.clearCookie('court')
+    }
+    res.redirect(302, cookies && cookies.currentCourt ? `/${cookies.currentCourt}/cases` : '/my-courts/setup')
   })
 
   router.get('/user-guide', (req, res) => {
@@ -101,7 +105,7 @@ module.exports = function Index ({ authenticationMiddleware }) {
     const { params: { courtCode } } = req
 
     res.status(201)
-      .cookie('court', courtCode)
+      .cookie('currentCourt', courtCode)
       .redirect(302, `/${courtCode}/cases/${getBaseDateString()}`)
   })
 


### PR DESCRIPTION
As we're putting the user preferences service live tonight I realised that if the user currently has the court cookie then they won't get the new onboarding journey and will therefore not store their chosen court(s) in the user preferences service.

In order to ensure all users will get the new experience I have chosen to rename the cookie to currentCourt.

I have also included some code to remove the old court cookie to make sure it's not hanging about on all our current users' machines.

We can remove this code at a later date.

♻️ Renamed the court cookie
🚧 Included code to remove the old cookie which will need to be removed at a later date.

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>