### PR TITLE
:zap: PIC-1175: Added new single conviction endpoint

### DIFF
--- a/integration-tests/integration/features/case-summary.feature
+++ b/integration-tests/integration/features/case-summary.feature
@@ -266,7 +266,7 @@ Feature: Case summary
     And I should see the body text "Last attended: 4 Mar 2020 - Planned office visit (Acceptable)"
 
     And I should see the text "Order started" within element with class "qa-start-title"
-    And I should see the text "Order ends" within element with class "qa-end-title"
+    And I should see the text "Order ended" within element with class "qa-end-title"
     And I should see the text "Time elapsed" within element with class "qa-elapsed-title"
 
     And I should see the text "20 May 2019" within element with class "qa-start-date"
@@ -370,7 +370,7 @@ Feature: Case summary
     And I should see the body text "Last attended: 10 Mar 2020 - Unpaid work (Acceptable)"
 
     And I should see the text "Order started" within element with class "qa-start-title"
-    And I should see the text "Order ends" within element with class "qa-end-title"
+    And I should see the text "Order ended" within element with class "qa-end-title"
     And I should see the text "Time elapsed" within element with class "qa-elapsed-title"
 
     And I should see the text "7 Oct 2018" within element with class "qa-start-date"

--- a/mappings/community/D541487-conviction-1531139839.json
+++ b/mappings/community/D541487-conviction-1531139839.json
@@ -1,0 +1,45 @@
+{
+  "id": "116fce2c-9c2d-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/D541487/convictions/1531139839"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+          "convictionId": "1531139839",
+          "active": false,
+          "inBreach": true,
+          "convictionDate": "2018-01-06",
+          "offences": [
+            {
+              "description": "Noise offences - 82200"
+            },
+            {
+              "description": "Acknowledging bail in false name - 08303"
+            },
+            {
+              "description": "Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"
+            },
+            {
+              "description": "Highways Acts - Other offences, other than those caused by vehicles - 12400"
+            }
+          ],
+          "sentence": {
+            "sentenceId": "123123140",
+            "description": "CJA - Indeterminate Public Prot.",
+            "length": 18,
+            "lengthInDays": 547,
+            "lengthUnits": "Months",
+            "terminationDate": "2019-07-12",
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-01-06",
+            "endDate": "2019-07-12"
+          },
+          "documents": []
+        }
+  }
+}

--- a/mappings/community/D814575-conviction-241412130.json
+++ b/mappings/community/D814575-conviction-241412130.json
@@ -1,0 +1,42 @@
+{
+  "id": "097e8104-9c2d-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/D814575/convictions/241412130"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+          "convictionId": "241412130",
+          "active": false,
+          "inBreach": true,
+          "convictionDate": "2018-07-06",
+          "offences": [
+            {
+              "description": "Stealing mail bags or postal packets or unlawfully taking away or opening mail bag - 04200"
+            },
+            {
+              "description": "High treason - 06200"
+            },
+            {
+              "description": "Common assault and battery - 10501"
+            }
+          ],
+          "sentence": {
+            "sentenceId": "123123141",
+            "description": "CJA - Indeterminate Public Prot.",
+            "length": 18,
+            "lengthUnits": "Months",
+            "lengthInDays": 547,
+            "terminationDate": "2020-01-06",
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-07-06",
+            "endDate": "2020-01-06"
+          },
+          "documents": []
+        }
+  }
+}

--- a/mappings/community/D985513-conviction-1679300004.json
+++ b/mappings/community/D985513-conviction-1679300004.json
@@ -1,0 +1,57 @@
+{
+  "id": "0312212c-9c2d-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/D985513/convictions/1679300004"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+          "convictionId": "1679300004",
+          "active": true,
+          "inBreach": false,
+          "convictionDate": "2018-11-23",
+          "offences": [
+            {
+                "description": "Acknowledging bail in false name - 08303"
+              },
+            {
+                "description": "Detaining and threatening to kill or injure a hostage (Taking of Hostages Act 1982) - 03604"
+              }
+          ],
+          "sentence": {
+            "sentenceId": "123123141",
+            "description": "CJA - Std Determinate Custody",
+            "length": 18,
+            "lengthUnits": "Months",
+            "lengthInDays": 547,
+            "terminationDate": "2020-05-23",
+            "terminationReason": "Auto Terminated",
+            "startDate": "2018-11-23",
+            "endDate": "2020-05-23"
+          },
+          "documents": [
+            {
+              "documentId": "1d842fce-ec2d-45dc-ac9a-748d3076ca6b",
+              "documentName": "shortFormatPreSentenceReport_04092019_121424_OMIC_A_X320741.pdf",
+              "author": "Andy Marke",
+              "type": "COURT_REPORT_DOCUMENT",
+              "extendedDescription": "Pre-Sentence Report - Fast requested by Sheffield Crown Court on 04/09/2018",
+              "createdAt": "2019-09-04T00:00:00",
+              "subType": {
+                "code": "CJF",
+                "description": "Pre-Sentence Report - Fast"
+              },
+              "reportDocumentDates": {
+                "requestedDate": "2018-09-04",
+                "requiredDate": "2019-09-04",
+                "completedDate": "2018-02-28T00:00:00"
+              }
+            }
+          ]
+        }
+  }
+}

--- a/mappings/community/D991494-conviction-1361422142.json
+++ b/mappings/community/D991494-conviction-1361422142.json
@@ -1,0 +1,80 @@
+{
+  "id": "f9ccbf6e-9c2c-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/D991494/convictions/1361422142"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+          "convictionId": "1361422142",
+          "active": true,
+          "inBreach": true,
+          "convictionDate": "2018-10-07",
+          "offences": [
+            {
+              "description": "Abstracting electricity - 04300"
+            },
+            {
+              "description": "Common and other types of assault - 10500"
+            },
+            {
+              "description": "(Assault PC (Indictable/Either way) - 00807)"
+            }
+          ],
+          "breaches": [
+            {
+              "breachId": 12345,
+              "description": "Community Order/SSO Breach",
+              "statusDate": "2014-12-30",
+              "status": "In progress"
+            },
+            {
+              "breachId": 54321,
+              "description": "Community Order/SSO Breach",
+              "statusDate": "2014-12-26",
+              "status": "Breach Summons Issued"
+            },
+            {
+              "breachId": 98765,
+              "description": "Community Order/SSO Breach",
+              "statusDate": "2013-11-26",
+              "status": "Completed - Amended & Continued"
+            }
+          ],
+          "sentence": {
+            "sentenceId": "123123140",
+            "description": "ORA Community Order",
+            "length": 18,
+            "lengthUnits": "Months",
+            "lengthInDays": 547,
+            "terminationDate": "2020-04-07",
+            "terminationReason": "Auto Terminated",
+            "startDate":  "2018-10-07",
+            "endDate": "2020-06-17"
+          },
+          "documents": [
+            {
+              "documentId": "1d842fce-ec2d-45dc-ac9a-748d3076ca6b",
+              "documentName": "shortFormatPreSentenceReport_04092019_121424_OMIC_A_X320741.pdf",
+              "author": "Andy Marke",
+              "type": "COURT_REPORT_DOCUMENT",
+              "extendedDescription": "Pre-Sentence Report - Fast requested by Sheffield Crown Court on 08/10/2018",
+              "createdAt": "2019-10-08T00:00:00",
+              "subType": {
+                "code": "CJF",
+                "description": "Pre-Sentence Report - Fast"
+              },
+              "reportDocumentDates": {
+                "requestedDate": "2018-10-08",
+                "requiredDate": "2019-10-08",
+                "completedDate": "{{now offset='-5 days' format='yyyy-MM-dd'}}T00:00:00"
+              }
+            }
+          ]
+        }
+  }
+}

--- a/mappings/community/DX12340A-conviction-1309234876.json
+++ b/mappings/community/DX12340A-conviction-1309234876.json
@@ -1,0 +1,76 @@
+{
+  "id": "d5441214-9c2c-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/DX12340A/convictions/1309234876"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+
+      "convictionId": "1309234876",
+      "active": true,
+      "inBreach": false,
+      "convictionDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+      "offences": [
+        {
+          "description": "Dangerous driving/Aid, abet cause or permit reckless driving - 80200"
+        },
+        {
+          "description": "Town and Country Planning Act 1990/Planning (Listed Buildings and Conservation Areas) Act 1990/Planning (Hazardous Substances Act) - 09400"
+        },
+        {
+          "description": "Aiding suicide - 07600"
+        },
+        {
+          "description": "Aggravated burglary in a building other than a dwelling (including attempts) - 03100"
+        }
+      ],
+      "sentence": {
+        "sentenceId": "123123128",
+        "description": "ORA Adult Custody (inc PSS)",
+        "length": 12,
+        "lengthInDays": 365,
+        "lengthUnits": "Months",
+        "terminationDate": "2018-01-23",
+        "terminationReason": "ICMS Miscellaneous Event",
+        "currentOrderHeaderDetail" : {
+          "custodialTypeCode" : "B",
+          "custodialTypeDescription": "ORA Adult Custody (inc PSS)",
+          "mainOffenceDescription": "Dangerous driving/Aid, abet cause or permit reckless driving - 80200",
+          "status": "Released - On Licence",
+          "disposalDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+          "actualReleaseDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+          "licenceExpiryDate": "{{now offset='6 months' format='yyyy-MM-dd'}}",
+          "pssEndDate": "{{now offset='12 months' format='yyyy-MM-dd'}}",
+          "length": 12,
+          "lengthUnit": "Months"
+        },
+        "startDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+        "endDate": "{{now offset='6 months' format='yyyy-MM-dd'}}"
+      },
+      "documents": [
+        {
+          "documentId": "1d842fce-ec2d-45dc-ac9a-748d3076ca6b",
+          "documentName": "shortFormatPreSentenceReport_04092019_121424_OMIC_A_X320741.pdf",
+          "author": "John Smith",
+          "type": "COURT_REPORT_DOCUMENT",
+          "extendedDescription": "Pre-Sentence Report - Fast requested by Sheffield Crown Court on 27/02/2018",
+          "createdAt": "2018-02-28T00:00:00",
+          "subType": {
+            "code": "CJF",
+            "description": "Pre-Sentence Report - Fast"
+          },
+          "reportDocumentDates": {
+            "requestedDate": "2018-02-27",
+            "requiredDate": "2018-02-28",
+            "completedDate": "2018-02-28T00:00:00"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/mappings/community/DX12340A-conviction-1403337513.json
+++ b/mappings/community/DX12340A-conviction-1403337513.json
@@ -1,0 +1,63 @@
+{
+  "id": "ce0a5bde-9c2c-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/DX12340A/convictions/1403337513"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "convictionId": "1403337513",
+      "active": true,
+      "inBreach": false,
+      "convictionDate": "2019-05-19",
+      "offences": [
+        {
+          "description": "Stealing mail bags or postal packets or unlawfully taking away or opening mail bag - 04200"
+        },
+        {
+          "description": "Common and other types of assault - 10500"
+        },
+        {
+          "description": "(Adulteration etc of milk products - 08902)"
+        },
+        {
+          "description": "Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"
+        }
+      ],
+      "sentence": {
+        "sentenceId": "123123127",
+        "description": "ORA Community Order",
+        "length": 18,
+        "lengthInDays": 547,
+        "lengthUnits": "Months",
+        "terminationDate": "2018-01-23",
+        "terminationReason": "ICMS Miscellaneous Event",
+        "startDate": "2019-05-20",
+        "endDate": "2020-05-25"
+      },
+      "documents": [
+        {
+          "documentId": "66b66bd6-b1fd-4883-a23d-609c16284abc",
+          "documentName": "shortFormatPreSentenceReport_X320741_121424_OMIC_A_04092019.pdf",
+          "author": "John Jones",
+          "type": "COURT_REPORT_DOCUMENT",
+          "extendedDescription": "Pre-Sentence Report - Fast requested by Sheffield Crown Court on 01/01/2018",
+          "createdAt": "2019-09-04T00:00:00",
+          "subType": {
+            "code": "CJF",
+            "description": "Pre-Sentence Report - Fast"
+          },
+          "reportDocumentDates": {
+            "requestedDate": "2018-01-01",
+            "requiredDate": "2018-01-02",
+            "completedDate": "2018-01-02T00:00:00"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/mappings/community/DX12340A-conviction-2360414697.json
+++ b/mappings/community/DX12340A-conviction-2360414697.json
@@ -1,0 +1,57 @@
+{
+  "id": "c589c1de-9c2c-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/DX12340A/convictions/2360414697"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "convictionId": "2360414697",
+      "active": true,
+      "inBreach": false,
+      "convictionDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+      "offences": [
+        {
+          "description": "Aggravated burglary in a building other than a dwelling (including attempts) - 03100"
+        },
+        {
+          "description": "Abstracting electricity - 04300"
+        },
+        {
+          "description": "(Adulteration etc of milk products - 08902)"
+        },
+        {
+          "description": "Common assault and battery - 10501"
+        }
+      ],
+      "sentence": {
+        "sentenceId": "123123130",
+        "description": "ORA Adult Custody (inc PSS)",
+        "length": 18,
+        "lengthInDays": 547,
+        "lengthUnits": "Months",
+        "terminationDate": "{{now offset='5 months' format='yyyy-MM-dd'}}",
+        "terminationReason": "ICMS Miscellaneous Event",
+        "currentOrderHeaderDetail" : {
+          "custodialTypeCode" : "P",
+          "custodialTypeDescription": "ORA Adult Custody (inc PSS)",
+          "mainOffenceDescription": "Aggravated burglary in a building other than a dwelling (including attempts) - 03100",
+          "status": "Post Sentence Supervision",
+          "disposalDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+          "actualReleaseDate": "{{now format='yyyy-MM-dd'}}",
+          "licenceExpiryDate": "{{now format='yyyy-MM-dd'}}",
+          "pssEndDate": "{{now offset='5 months' format='yyyy-MM-dd'}}",
+          "length": 11,
+          "lengthUnit": "Months"
+        },
+        "startDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+        "endDate": "2020-07-01"
+      },
+      "documents": []
+    }
+  }
+}

--- a/mappings/community/DX12340A-conviction-636401162.json
+++ b/mappings/community/DX12340A-conviction-636401162.json
@@ -1,0 +1,39 @@
+{
+  "id": "e011045e-9c2c-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/DX12340A/convictions/636401162"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "convictionId": "636401162",
+      "active": false,
+      "inBreach": true,
+      "convictionDate": "2017-03-08",
+      "offences": [
+        {
+          "description": "Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"
+        },
+        {
+          "description": "Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"
+        }
+      ],
+      "sentence": {
+        "sentenceId": "123123121",
+        "description": "CJA - Std Determinate Custody",
+        "length": 18,
+        "lengthInDays": 547,
+        "lengthUnits": "Months",
+        "terminationDate": "2018-01-23",
+        "terminationReason": "ICMS Miscellaneous Event",
+        "startDate": "2017-03-08",
+        "endDate": "2018-09-08"
+      },
+      "documents": []
+    }
+  }
+}

--- a/mappings/community/DX12340A-requirements-2360414697.json
+++ b/mappings/community/DX12340A-requirements-2360414697.json
@@ -1,5 +1,5 @@
 {
-  "id": "80cd54d5-ca72-49fc-ac7b-eda0b93a9a08",
+  "id": "0e2a8248-9c50-11eb-a8b3-0242ac130003",
   "request": {
     "method": "GET",
     "urlPathPattern": "/offender/DX12340A/convictions/2360414697/requirements"

--- a/mappings/community/E654321-conviction-345464567.json
+++ b/mappings/community/E654321-conviction-345464567.json
@@ -1,0 +1,39 @@
+{
+  "id": "37f401b8-9c4a-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/E654321/convictions/345464567"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+          "convictionId": "345464567",
+          "active": true,
+          "inBreach": true,
+          "convictionDate": "2017-03-08",
+          "offences": [
+            {
+              "description": "Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"
+            },
+            {
+              "description": "Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"
+            }
+          ],
+          "sentence": {
+            "sentenceId": "99483532",
+            "description": "CJA - Std Determinate Custody",
+            "length": 18,
+            "lengthInDays": 547,
+            "lengthUnits": "Months",
+            "terminationDate": "2018-01-23",
+            "terminationReason": "ICMS Miscellaneous Event",
+            "startDate": "2017-03-08",
+            "endDate": "2018-09-08"
+          },
+          "documents": []
+        }
+    }
+}

--- a/mappings/community/default-conviction.json
+++ b/mappings/community/default-conviction.json
@@ -1,0 +1,57 @@
+{
+  "id": "a43ef436-9b96-11eb-a8b3-0242ac130003",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/offender/([A-Z0-9]*)/convictions/(?!1403337513|636401162|1309234876|241412130|1531139839|345464567|2360414697)([0-9]*)"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody": {
+      "convictionId": "1403337513",
+      "active": false,
+      "inBreach": false,
+      "convictionDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+      "offences": [
+        {
+          "description": "Aggravated burglary in a building other than a dwelling (including attempts) - 03100"
+        },
+        {
+          "description": "Abstracting electricity - 04300"
+        },
+        {
+          "description": "(Adulteration etc of milk products - 08902)"
+        },
+        {
+          "description": "Common assault and battery - 10501"
+        }
+      ],
+      "sentence": {
+        "sentenceId": "123123130",
+        "description": "ORA Adult Custody (inc PSS)",
+        "length": 18,
+        "lengthInDays": 547,
+        "lengthUnits": "Months",
+        "terminationDate": "{{now offset='5 months' format='yyyy-MM-dd'}}",
+        "terminationReason": "ICMS Miscellaneous Event",
+        "currentOrderHeaderDetail" : {
+          "custodialTypeCode" : "P",
+          "custodialTypeDescription": "ORA Adult Custody (inc PSS)",
+          "mainOffenceDescription": "Aggravated burglary in a building other than a dwelling (including attempts) - 03100",
+          "status": "Post Sentence Supervision",
+          "disposalDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+          "actualReleaseDate": "{{now format='yyyy-MM-dd'}}",
+          "licenceExpiryDate": "{{now format='yyyy-MM-dd'}}",
+          "pssEndDate": "{{now offset='5 months' format='yyyy-MM-dd'}}",
+          "length": 11,
+          "lengthUnit": "Months"
+        },
+        "startDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}",
+        "endDate": "2020-07-01"
+      },
+      "documents": []
+    }
+  }
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,6 +7,7 @@ const {
   getDetails,
   getProbationRecord,
   getProbationRecordWithRequirements,
+  getConvictionWithRequirements,
   getProbationStatusDetails,
   getSentenceDetails,
   getBreachDetails,
@@ -209,11 +210,10 @@ module.exports = function Index ({ authenticationMiddleware }) {
     templateValues.title = 'Order details'
 
     const { data: { crn } } = templateValues
-    let communityResponse = await getProbationRecordWithRequirements(crn)
+    let communityResponse = await getConvictionWithRequirements(crn, convictionId)
 
-    if (communityResponse.convictions) {
-      const { active, sentence } = communityResponse.convictions
-        .find(conviction => conviction.convictionId.toString() === convictionId.toString())
+    if (communityResponse) {
+      const { active, sentence } = communityResponse
       if (active) {
         const sentenceDetails = await getSentenceDetails(crn, convictionId, sentence.sentenceId)
         communityResponse = {

--- a/server/services/community-service.js
+++ b/server/services/community-service.js
@@ -15,9 +15,31 @@ const getRequirements = async (convictions, crn, activeOnly) => {
   )
 }
 
+const getRequirementsForSingleConviction = async (convictionId, crn) => {
+  const res = await request(`${apiUrl}/offender/${crn}/convictions/${convictionId}/requirements`)
+  return res.data
+}
+
+const getConviction = async (crn, convictionId) => {
+  const res = await request(`${apiUrl}/offender/${crn}/convictions/${convictionId}`) || { data: {} }
+  return res.data
+}
+
 const getProbationRecord = async crn => {
   const res = await request(`${apiUrl}/offender/${crn}/probation-record`) || { data: {} }
   return res.status >= 400 ? res : res.data
+}
+
+const getConvictionWithRequirements = async (crn, convictionId) => {
+  const responseData = await getConviction(crn, convictionId)
+  if (responseData) {
+    const enrichedConviction = await getRequirementsForSingleConviction(convictionId, crn)
+    return {
+      ...responseData,
+      conviction: enrichedConviction
+    }
+  }
+  return responseData
 }
 
 const getProbationRecordWithRequirements = async (crn, activeOnly = false) => {
@@ -64,10 +86,13 @@ const getRiskDetails = async crn => {
 module.exports = {
   getDetails,
   getProbationRecord,
+  getConvictionWithRequirements,
   getProbationRecordWithRequirements,
   getProbationStatusDetails,
   getSentenceDetails,
   getBreachDetails,
   getAttachment,
-  getRiskDetails
+  getRiskDetails,
+  getConviction,
+  getRequirementsForSingleConviction
 }

--- a/server/views/case-summary-record-order.njk
+++ b/server/views/case-summary-record-order.njk
@@ -22,22 +22,14 @@
 
 {%- set communityData = data.communityData -%}
 
-{%- set currentOrder = {} -%}
-{%- for order in communityData.convictions if communityData.convictions | length %}
-    {% if order.convictionId | string === params.convictionId | string %}
-        {%- set currentOrder = order -%}
-    {% endif %}
-{% endfor -%}
-
-{% if currentOrder.sentence.currentOrderHeaderDetail.custodialTypeCode %}
-    {%- set custodialOrder = currentOrder.sentence.currentOrderHeaderDetail -%}
+{% if communityData.sentence.currentOrderHeaderDetail.custodialTypeCode %}
+    {%- set custodialOrder = communityData.sentence.currentOrderHeaderDetail -%}
     {%- set isOnLicence = moment(custodialOrder.licenceExpiryDate, 'YYYY-MM-DD').isAfter() -%}
 {% endif %}
 
 {%- set preciseDiff = params.preciseDiff -%}
 
-
-{%- for requirement in currentOrder.requirements %}
+{%- for requirement in communityData.conviction.requirements %}
     {% set category = requirement.requirementTypeMainCategory.description or requirement.adRequirementTypeMainCategory.description %}
     {% set subCategory = requirement.requirementTypeSubCategory.description or requirement.adRequirementTypeSubCategory.description %}
 
@@ -53,13 +45,13 @@
     ]) }}
 {% endfor -%}
 
-{%- if moment(currentOrder.sentence.endDate, 'YYYY-MM-DD').isAfter() -%}
-    {%- set elapsedTime = params.getMonthsAndDays(moment(currentOrder.sentence.startDate, 'YYYY-MM-DD'), moment()) -%}
+{%- if moment(communityData.sentence.endDate, 'YYYY-MM-DD').isAfter() -%}
+    {%- set elapsedTime = params.getMonthsAndDays(moment(communityData.sentence.startDate, 'YYYY-MM-DD'), moment()) -%}
 {%- else -%}
-    {%- set elapsedTime = params.getMonthsAndDays(moment(currentOrder.sentence.startDate, 'YYYY-MM-DD'), moment(currentOrder.sentence.endDate, 'YYYY-MM-DD')) -%}
+    {%- set elapsedTime = params.getMonthsAndDays(moment(communityData.sentence.startDate, 'YYYY-MM-DD'), moment(communityData.sentence.endDate, 'YYYY-MM-DD')) -%}
 {%- endif -%}
 
-{% if currentOrder.active %}
+{% if communityData.active %}
     {# Group appointments by attended/absent and complied/failed #}
     {%- set attendances = communityData.sentenceDetails.attendances or [] -%}
     {%- set attendedAppointments = {
@@ -130,13 +122,13 @@
 
 {% block caseContent %}
 
-    <h2 class="govuk-heading-l govuk-!-margin-0">{{ currentOrder.sentence.description + (' (' + currentOrder.sentence.length + ' ' + currentOrder.sentence.lengthUnits + ')' if currentOrder.sentence.length)}}</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-0">{{ communityData.sentence.description + (' (' + communityData.sentence.length + ' ' + communityData.sentence.lengthUnits + ')' if communityData.sentence.length)}}</h2>
 
     <div class="govuk-grid-row govuk-!-margin-top-6">
         <div class="govuk-grid-column-two-thirds">
 
             <p class="govuk-body govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-                {{ currentOrder.offences[0].description }}
+                {{ communityData.offences[0].description }}
             </p>
 
             <div class="govuk-grid-row">
@@ -146,7 +138,7 @@
                         {%- if custodialOrder -%}
                             {{ "On licence" if custodialOrder.custodialTypeCode === "B" else "On post-sentence supervision (PSS)" }}
                         {% else %}
-                            {{ moment(currentOrder.sentence.startDate, 'YYYY-MM-DD').format(displayDateFormat) }}
+                            {{ moment(communityData.sentence.startDate, 'YYYY-MM-DD').format(displayDateFormat) }}
                         {% endif %}
                     </p>
                 </div>
@@ -162,7 +154,7 @@
                         {% if custodialOrder %}
                             {{ moment(custodialOrder.disposalDate, 'YYYY-MM-DD').format(displayDateFormat) if isOnLicence else moment(custodialOrder.licenceExpiryDate, 'YYYY-MM-DD').format(displayDateFormat) }}
                         {% else %}
-                            {{ moment(currentOrder.sentence.endDate, 'YYYY-MM-DD').format(displayDateFormat) if currentOrder.active else moment(currentOrder.sentence.terminationDate, 'YYYY-MM-DD').format(displayDateFormat) }}
+                            {{ moment(communityData.sentence.endDate, 'YYYY-MM-DD').format(displayDateFormat) if communityData.active else moment(communityData.sentence.terminationDate, 'YYYY-MM-DD').format(displayDateFormat) }}
                         {% endif %}
                     </p>
                 </div>
@@ -171,35 +163,35 @@
                         {% if custodialOrder %}
                             {{ "Licence ends" if isOnLicence else "PSS ends" }}
                         {% else %}
-                            {{ "Time elapsed" if currentOrder.active else "Reason" }}
+                            {{ "Time elapsed" if communityData.active else "Reason" }}
                         {% endif %}
                     </p>
                     <p class="govuk-body-l govuk-!-font-weight-bold govuk-!-margin-0 qa-elapsed-time">
                         {% if custodialOrder %}
                             {{ moment(custodialOrder.licenceExpiryDate, 'YYYY-MM-DD').format(displayDateFormat) if isOnLicence else moment(custodialOrder.pssEndDate, 'YYYY-MM-DD').format(displayDateFormat) }}
                         {% else %}
-                            {{ elapsedTime if currentOrder.active else currentOrder.sentence.terminationReason }}
+                            {{ elapsedTime if communityData.active else communityData.sentence.terminationReason }}
                         {% endif %}
                     </p>
                 </div>
             </div>
 
-                {% if currentOrder.licenceConditions | length %}
+                {% if communityData.conviction.licenceConditions | length %}
                     <h2 class="govuk-heading-m govuk-!-margin-top-8">Licence conditions</h2>
                     <ul class="govuk-list govuk-list--bullet qa-current-requirements-{{ loop.index0 }}">
-                        {%- for licenceConditions in currentOrder.licenceConditions %}
+                        {%- for licenceConditions in communityData.conviction.licenceConditions %}
                             <li>
                                 {{ licenceConditions.description }}
                             </li>
                         {% endfor %}
                     </ul>
-                    <a href="/{{ params.courtCode }}/case/{{ data.caseNo }}/record/{{ currentOrder.convictionId }}/licence-details" class=" govuk-body-m govuk-link govuk-link--no-visited-state">View licence conditions details</a>
+                    <a href="/{{ params.courtCode }}/case/{{ data.caseNo }}/record/{{ communityData.convictionId }}/licence-details" class=" govuk-body-m govuk-link govuk-link--no-visited-state">View licence conditions details</a>
                 {% endif %}
 
-                {% if currentOrder.pssRequirements | length %}
+                {% if communityData.pssRequirements | length %}
                     <h2 class="govuk-heading-m govuk-!-margin-top-8">Post-sentence supervision requirements</h2>
                     <ul class="govuk-list govuk-list--bullet qa-current-requirements-{{ loop.index0 }}">
-                        {%- for pssRequirement in currentOrder.pssRequirements %}
+                        {%- for pssRequirement in communityData.pssRequirements %}
                             <li>
                                 {{ pssRequirement.description  + (' - ' + pssRequirement.subTypeDescription if pssRequirement.subTypeDescription | length) }}
                             </li>
@@ -207,11 +199,11 @@
                     </ul>
                 {% endif %}
 
-            {% if currentOrder.requirements | length %}
+            {% if communityData.conviction.requirements | length %}
                 <h2 class="govuk-heading-m govuk-!-margin-top-8">Requirements</h2>
 
                 {%- from "govuk/components/table/macro.njk" import govukTable -%}
-                {% if currentOrder.active %}
+                {% if communityData.active %}
                     {{ govukTable(activeRequirementTableData) }}
                 {% else %}
                     {{ govukTable(inactiveRequirementTableData) }}
@@ -221,7 +213,7 @@
         </div>
     </div>
 
-    {% if currentOrder.breaches | length %}
+    {% if communityData.breaches | length %}
         <h2 class="govuk-heading-m govuk-!-margin-top-8">Breaches</h2>
         <div class="govuk-grid-row govuk-!-margin-bottom-6">
             <div class="govuk-grid-column-two-thirds">
@@ -234,10 +226,10 @@
                     </tr>
                     </thead>
                     <tbody class="govuk-table__body qa-breaches">
-                    {% for breach in currentOrder.breaches %}
+                    {% for breach in communityData.breaches %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell"><a
-                                        href="{{ currentOrder.convictionId }}/breach/{{ breach.breachId }}"
+                                        href="{{ communityData.convictionId }}/breach/{{ breach.breachId }}"
                                         class="qa-breach-link-{{ loop.index }} govuk-link govuk-link--no-visited-state">{{ breach.description }}</a>
                             </td>
                             <td class="govuk-table__cell">{{ breach.status }}</td>
@@ -250,7 +242,7 @@
         </div>
     {% endif %}
 
-    {% if currentOrder.active %}
+    {% if communityData.active %}
 
         <h2 class="govuk-heading-m govuk-!-margin-top-8">Attendance</h2>
 

--- a/tests/pact/community-service/get-conviction.test.pact.js
+++ b/tests/pact/community-service/get-conviction.test.pact.js
@@ -1,0 +1,39 @@
+/* global describe, it, expect */
+const { pactWith } = require('jest-pact')
+const { Matchers } = require('@pact-foundation/pact')
+
+const { parseMockResponse } = require('../../testUtils/parseMockResponse')
+const { request } = require('../../../server/services/utils/request')
+const convictionMock = require('../../../mappings/community/DX12340A-conviction-1309234876.json')
+
+pactWith({ consumer: 'Prepare a case', provider: 'Court case service' }, provider => {
+  describe('GET /offender/{crn}/convictions/{convictionId}', () => {
+    const crn = 'DX12340A'
+    const convictionId = '1309234876'
+    const apiUrl = `/offender/${crn}/convictions/${convictionId}`
+    const parsedMockData = parseMockResponse(convictionMock.response.jsonBody)
+
+    it('returns the data for a single conviction', async () => {
+      await provider.addInteraction({
+        state: 'a defendant has an existing conviction',
+        uponReceiving: 'a request for data of a specific conviction',
+        withRequest: {
+          method: 'GET',
+          path: apiUrl,
+          headers: {
+            Accept: 'application/json'
+          }
+        },
+        willRespondWith: {
+          status: convictionMock.response.status,
+          headers: convictionMock.response.headers,
+          body: Matchers.like(parsedMockData)
+        }
+      })
+
+      const response = await request(`${provider.mockService.baseUrl}${apiUrl}`)
+      expect(response.data).toEqual(parsedMockData)
+      return response
+    })
+  })
+})

--- a/tests/routes/view.test.js
+++ b/tests/routes/view.test.js
@@ -57,6 +57,10 @@ describe('Routes', () => {
     return communityResponse
   })
 
+  jest.spyOn(communityService, 'getConvictionWithRequirements').mockImplementation(function () {
+    return communityResponse
+  })
+
   jest.spyOn(communityService, 'getDetails').mockImplementation(function () {
     return communityResponse
   })
@@ -186,23 +190,31 @@ describe('Routes', () => {
     return response
   })
 
+  it('case summary get conviction route should call the case service to fetch data for a single conviction', async () => {
+    caseResponse = {
+      probationStatus: 'Current',
+      crn: 'D985513'
+    }
+    const response = await request(app).get('/B14LO/case/8678951874/record/1403337513')
+    expect(caseService.getCase).toHaveBeenCalledWith('B14LO', '8678951874')
+    expect(communityService.getConvictionWithRequirements).toHaveBeenCalledWith('D985513', '1403337513')
+    return response
+  })
+
   it('case summary attendance route should call the case service to fetch attendance data', async () => {
     caseResponse = {
       probationStatus: 'Current',
       crn: 'D985513'
     }
     communityResponse = {
-      convictions: [{
-        convictionId: 1403337513,
-        active: true,
-        sentence: {
-          sentenceId: '12345678'
-        }
-      }]
+      convictionId: 1403337513,
+      active: true,
+      sentence: {
+        sentenceId: '12345678'
+      }
     }
     const response = await request(app).get('/B14LO/case/668911253/record/1403337513')
     expect(caseService.getCase).toHaveBeenCalledWith('B14LO', '668911253')
-    expect(communityService.getProbationRecordWithRequirements).toHaveBeenCalledWith('D985513')
     expect(communityService.getSentenceDetails).toHaveBeenCalledWith('D985513', '1403337513', '12345678')
     return response
   })
@@ -220,7 +232,6 @@ describe('Routes', () => {
     }
     const response = await request(app).get('/B14LO/case/668911253/record/1403337513')
     expect(caseService.getCase).toHaveBeenCalledWith('B14LO', '668911253')
-    expect(communityService.getProbationRecordWithRequirements).toHaveBeenCalledWith('D985513')
     expect(communityService.getSentenceDetails).not.toHaveBeenCalled()
     return response
   })

--- a/tests/services/community-service.test.js
+++ b/tests/services/community-service.test.js
@@ -8,7 +8,9 @@ const {
   getProbationRecord,
   getProbationRecordWithRequirements,
   getProbationStatusDetails,
-  getBreachDetails
+  getBreachDetails,
+  getConviction,
+  getConvictionWithRequirements
 } = require('../../server/services/community-service')
 
 const apiUrl = config.apis.courtCaseService.url
@@ -80,6 +82,45 @@ describe('Community service', () => {
     })
 
     const response = await getProbationRecordWithRequirements('D123456')
+    expect(moxios.requests.mostRecent().url).toBe(`${apiUrl}/offender/D123456/convictions/12345/requirements`)
+    return response
+  })
+
+  it('should call the API to request data for a single conviction', async () => {
+    moxios.stubRequest(`${apiUrl}/offender/D123456/convictions/12345678`, {
+      status: 200,
+      response: {
+        active: false
+      }
+    })
+
+    const response = await getConviction('D123456', '12345678')
+    expect(moxios.requests.mostRecent().url).toBe(`${apiUrl}/offender/D123456/convictions/12345678`)
+    return response
+  })
+
+  it('should call the API to request data for a single conviction with requirements', async () => {
+    moxios.stubRequest(`${apiUrl}/offender/D123456/convictions/12345`, {
+      status: 200,
+      response: {
+        convictionId: 12345,
+        active: true,
+        sentence: {
+          description: 'Some sentence'
+        }
+      }
+    })
+
+    moxios.stubRequest(`${apiUrl}/offender/D123456/convictions/12345/requirements`, {
+      status: 200,
+      response: {
+        requirements: [{
+          requirementId: 7925250000
+        }]
+      }
+    })
+
+    const response = await getConvictionWithRequirements('D123456', '12345')
     expect(moxios.requests.mostRecent().url).toBe(`${apiUrl}/offender/D123456/convictions/12345/requirements`)
     return response
   })


### PR DESCRIPTION
- added functionality to point to single conviction endpoint from court-case-service, so we can use this instead of the costly probation-record endpoint when requesting data for a single conviction
- amended current single conviction endpoint to use the new single conviction endpoint 
- added unit tests for new functions
- added pact test for getConviction
- added BDD data for single conviction 