### PR TITLE
Remove inline style

### DIFF
--- a/public/stylesheets/app/_overrides.scss
+++ b/public/stylesheets/app/_overrides.scss
@@ -37,6 +37,10 @@ pac-\!-width-40 {
   width: 40%;
 }
 
+pac-\!-valign-bottom {
+  vertical-align: bottom;
+}
+
 .pac-inline-header-banner {
   line-height: 0.25;
 }

--- a/server/views/case-summary-record.njk
+++ b/server/views/case-summary-record.njk
@@ -125,8 +125,7 @@
                                 </p>
                                 <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-0 qa-previous-order-{{ loop.index }}-offence">{{ order.offences[0].description }}</p>
                             </td>
-                            <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-width-one-third"
-                                style="vertical-align: bottom">
+                            <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-width-one-third pac-!-valign-bottom">
                                 <p class="govuk-hint govuk-!-margin-bottom-0 qa-termination-date qa-previous-order-{{ loop.index }}-end-date">
                                     Ended
                                     on {{ moment(order.sentence.terminationDate, 'YYYY-MM-DD').format(displayDateFormat) }}</p>


### PR DESCRIPTION
Inline styles are blocked by CSP so I've replaced this with an override class.
This is unrelated to Google Analytics issues.

:recycle: Replaced inline style with new class

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>