### PR TITLE
Cookie fix

### DIFF
--- a/config.js
+++ b/config.js
@@ -85,7 +85,8 @@ module.exports = {
   },
   session: {
     secret: get('SESSION_SECRET', 'prepare-a-case-insecure-default-session', requiredInProduction),
-    expiry: get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)
+    expiry: get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120),
+    cookieOptions: { maxAge: 365 * 24 * 60 * 60 * 1000 }
   },
   apis: {
     userPreferenceService: {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -23,12 +23,12 @@ module.exports = function Index ({ authenticationMiddleware }) {
   router.use(health)
 
   router.use((req, res, next) => {
-    const { path, url, cookies: { currentCourt, analyticsCookies } } = req
-    if (currentCourt) {
-      res.cookie('currentCourt', currentCourt, cookieOptions)
+    const { path, url, cookies } = req
+    if (cookies && cookies.currentCourt) {
+      res.cookie('currentCourt', cookies.currentCourt, cookieOptions)
     }
-    if (analyticsCookies) {
-      res.cookie('analyticsCookies', analyticsCookies, cookieOptions)
+    if (cookies && cookies.analyticsCookies) {
+      res.cookie('analyticsCookies', cookies.analyticsCookies, cookieOptions)
     }
     if (path.substr(-1) === '/' && path.length > 1) {
       const query = url.slice(path.length)

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const getBaseDateString = require('../utils/getBaseDateString')
-const { settings, nonce, notification } = require('../../config')
+const { settings, nonce, notification, session: { cookieOptions } } = require('../../config')
 const { getUserSelectedCourts, updateSelectedCourts } = require('../services/user-preference-service')
 const { getCaseList, getCase, getMatchDetails, updateCase } = require('../services/case-service')
 const {
@@ -23,7 +23,13 @@ module.exports = function Index ({ authenticationMiddleware }) {
   router.use(health)
 
   router.use((req, res, next) => {
-    const { path, url } = req
+    const { path, url, cookies: { currentCourt, analyticsCookies } } = req
+    if (currentCourt) {
+      res.cookie('currentCourt', currentCourt, cookieOptions)
+    }
+    if (analyticsCookies) {
+      res.cookie('analyticsCookies', analyticsCookies, cookieOptions)
+    }
     if (path.substr(-1) === '/' && path.length > 1) {
       const query = url.slice(path.length)
       res.redirect(301, path.slice(0, -1) + query)
@@ -116,7 +122,7 @@ module.exports = function Index ({ authenticationMiddleware }) {
     const { params: { courtCode } } = req
 
     res.status(201)
-      .cookie('currentCourt', courtCode)
+      .cookie('currentCourt', courtCode, cookieOptions)
       .redirect(302, `/${courtCode}/cases/${getBaseDateString()}`)
   })
 


### PR DESCRIPTION
:bug: Fix cookie expiry

The expiry for cookies stored for current court and analytics preference will now extend from the last visit to the application.
The user would now have to not use the application for 6 months to lose the cookie.