### PR TITLE
Pic 1372 add pre sentence record to filter

### DIFF
--- a/integration-tests/integration/features/case-list.feature
+++ b/integration-tests/integration/features/case-list.feature
@@ -1,5 +1,5 @@
 Feature: Case list
-  In order to view the list of cases sitting on the day in court
+  In order to view the list of cases sittigit ong on the day in court
   As an authenticated user
   I want to see a case list view
 
@@ -31,7 +31,7 @@ Feature: Case list
 
     And I should see the following table rows
       | Kara Ayers   | No record | Attempt theft from the person of another | 1st | Morning | 10 |
-      | Mann Carroll | Pre-sentence record | Assault by beating | 3rd | Morning | 2  |
+      | Mann Carroll | Pre-sentence record | Assault by beating             | 3rd | Morning | 2  |
 
     And I should see link "Kara Ayers" with href "/B14LO/case/8678951874/summary"
     And I should see link "Mann Carroll" with href "/B14LO/case/7483843110/summary"

--- a/integration-tests/integration/features/case-list.feature
+++ b/integration-tests/integration/features/case-list.feature
@@ -31,7 +31,7 @@ Feature: Case list
 
     And I should see the following table rows
       | Kara Ayers   | No record | Attempt theft from the person of another | 1st | Morning | 10 |
-      | Mann Carroll | No record | Assault by beating                       | 3rd | Morning | 2  |
+      | Mann Carroll | Pre-sentence record | Assault by beating | 3rd | Morning | 2  |
 
     And I should see link "Kara Ayers" with href "/B14LO/case/8678951874/summary"
     And I should see link "Mann Carroll" with href "/B14LO/case/7483843110/summary"
@@ -434,6 +434,44 @@ Feature: Case list
 
     And I should see the following table rows
       | Porter Salas | Current | Theft from the person of another | 2nd | Afternoon | 1 |
+
+    When I click the "Clear all" link
+
+    Then I should see a count of "207 cases"
+
+    And I should see the following table headings
+      | Defendant | Probation status | Offence | Listing | Session | Court |
+
+    And I should see the following table rows
+      | Kara Ayers | No record | Attempt theft from the person of another | 1st | Morning | 10 |
+
+    And There should be no a11y violations
+
+  Scenario: A user wants to filter the list to show only Pre-sentence record offenders and quickly clear the selections
+    Given I am an authenticated user
+    When I navigate to the "cases" route for today
+    Then I should be on the "Case list" page
+
+    And I should see a count of "207 cases"
+
+    And I should see the following table headings
+      | Defendant | Probation status | Offence | Listing | Session | Court |
+
+    And I should see the following table rows
+      | Kara Ayers | No record | Attempt theft from the person of another | 1st | Morning | 10 |
+
+    When I click the "Probation status" filter button
+    And I select the "Pre-sentence record" filter
+    And I click the "Apply filters" button
+
+    Then I should see a count of "1 case"
+
+    And I should see the following table headings
+      | Defendant | Probation status | Offence | Listing | Session | Court |
+
+    And I should see the following table rows
+      | Mann Carroll | Pre-sentence record | Assault by beating | 3rd | Morning | 2 |
+
 
     When I click the "Clear all" link
 

--- a/integration-tests/integration/features/case-list.feature
+++ b/integration-tests/integration/features/case-list.feature
@@ -1,5 +1,5 @@
 Feature: Case list
-  In order to view the list of cases sittigit ong on the day in court
+  In order to view the list of cases sitting on the day in court
   As an authenticated user
   I want to see a case list view
 

--- a/mappings/case-list/case-list-full.json
+++ b/mappings/case-list/case-list-full.json
@@ -70,7 +70,7 @@
           "listNo": "3rd",
           "crn": "D541487",
           "pnc": "A/1234560BA",
-          "probationStatus": "No record",
+          "probationStatus": "Pre-sentence record",
           "session": "MORNING",
           "previouslyKnownTerminationDate": null,
           "suspendedSentenceOrder": false,

--- a/server/utils/getCaseListFilters.js
+++ b/server/utils/getCaseListFilters.js
@@ -1,7 +1,7 @@
 module.exports = (caseListData, selectedFilters) => {
   const availableProbationStatuses = [...new Set(caseListData.map(item => item.probationStatus))]
   const probationStatuses = []
-  const statusOrder = ['Current', 'Previously known', 'No record']
+  const statusOrder = ['Current', 'Previously known', 'No record', 'Pre-sentence record']
   statusOrder.forEach(status => {
     if (availableProbationStatuses.includes(status)) {
       probationStatuses.push({ label: status, value: status })

--- a/server/utils/getCaseListFilters.js
+++ b/server/utils/getCaseListFilters.js
@@ -1,7 +1,7 @@
 module.exports = (caseListData, selectedFilters) => {
   const availableProbationStatuses = [...new Set(caseListData.map(item => item.probationStatus))]
   const probationStatuses = []
-  const statusOrder = ['Current', 'Previously known', 'No record', 'Pre-sentence record']
+  const statusOrder = ['Current', 'Pre-sentence record', 'Previously known', 'No record']
   statusOrder.forEach(status => {
     if (availableProbationStatuses.includes(status)) {
       probationStatuses.push({ label: status, value: status })


### PR DESCRIPTION
- Added new probation status `Pre-sentence record` to filter. They are dynamic so the only options shown in the filters are what we have in the data, so this change will be ok to add before the back end work has been done - if we have no Pre-sentence record coming back in the data then it won't be an option in the filter.
- Added a BDD test to demonstrate that it works
- Updated mock data to include an example of `Pre-sentence record`