### PR TITLE
PIC-1391 GA page load times

### DIFF
--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -39,6 +39,18 @@
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', '{{ googleAnalyticsKey }}');
+
+          // Feature detects Navigation Timing API support.
+          if (window.performance) {
+            // Gets the number of milliseconds since page load
+            // (and rounds the result since the value must be an integer).
+            var timeSincePageLoad = Math.round(performance.now());
+            // Sends the timing event to Google Analytics.
+            gtag('event', 'timing_complete', {
+              'name': 'load',
+              'value': timeSincePageLoad
+            });
+          }
         </script>
         {% endif %}
     {% endblock %}
@@ -162,20 +174,6 @@
     <script src="/moj/all.js"></script>
     <script src="/govuk/all.js"></script>
     <script>window.GOVUKFrontend.initAll()</script>
-
-    <script nonce="{{ nonce }}">
-      // Feature detects Navigation Timing API support.
-      if (window.performance) {
-        // Gets the number of milliseconds since page load
-        // (and rounds the result since the value must be an integer).
-        var timeSincePageLoad = Math.round(performance.now());
-        // Sends the timing event to Google Analytics.
-        gtag('event', 'timing_complete', {
-          'name': 'load',
-          'value': timeSincePageLoad
-        });
-      }
-    </script>
 {% endblock %}
 
 </body>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -39,18 +39,6 @@
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', '{{ googleAnalyticsKey }}');
-
-          // Feature detects Navigation Timing API support.
-          if (window.performance) {
-            // Gets the number of milliseconds since page load
-            // (and rounds the result since the value must be an integer).
-            var timeSincePageLoad = Math.round(performance.now());
-            // Sends the timing event to Google Analytics.
-            gtag('event', 'timing_complete', {
-              'name': 'load',
-              'value': timeSincePageLoad
-            });
-          }
         </script>
         {% endif %}
     {% endblock %}
@@ -174,6 +162,21 @@
     <script src="/moj/all.js"></script>
     <script src="/govuk/all.js"></script>
     <script>window.GOVUKFrontend.initAll()</script>
+    {% if analyticsCookies === 'accept' %}
+    <script nonce="{{ nonce }}">
+      // Feature detects Navigation Timing API support.
+      if (window.performance) {
+        // Gets the number of milliseconds since page load
+        // (and rounds the result since the value must be an integer).
+        var timeSincePageLoad = Math.round(performance.now());
+        // Sends the timing event to Google Analytics.
+        gtag('event', 'timing_complete', {
+          'name': 'load',
+          'value': timeSincePageLoad
+        });
+      }
+    </script>
+    {% endif %}
 {% endblock %}
 
 </body>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -162,6 +162,20 @@
     <script src="/moj/all.js"></script>
     <script src="/govuk/all.js"></script>
     <script>window.GOVUKFrontend.initAll()</script>
+
+    <script nonce="{{ nonce }}">
+      // Feature detects Navigation Timing API support.
+      if (window.performance) {
+        // Gets the number of milliseconds since page load
+        // (and rounds the result since the value must be an integer).
+        var timeSincePageLoad = Math.round(performance.now());
+        // Sends the timing event to Google Analytics.
+        gtag('event', 'timing_complete', {
+          'name': 'load',
+          'value': timeSincePageLoad
+        });
+      }
+    </script>
 {% endblock %}
 
 </body>


### PR DESCRIPTION
The default load times uses 1% of the visitors for the measurement by default so the average is 0.

Looking at https://developers.google.com/analytics/devguides/collection/gtagjs/user-timings this looks to do what we need, so this is what the PR is for.

I've included it at the page end to make sure the event fires after the whole page has loaded.