### PR TITLE
Upgrade Node and dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,11 @@ executors:
     working_directory: ~/app
   builder:
     docker:
-      - image: cimg/node:14.16.1-browsers
+      - image: cimg/node:14.17.0-browsers
     working_directory: ~/app
   integration-tests:
     docker:
-      - image: cimg/node:14.16.1-browsers
+      - image: cimg/node:14.17.0-browsers
       - image: bitnami/redis:5.0
         environment:
           ALLOW_EMPTY_PASSWORD=yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.1-alpine3.13
+FROM node:14.17.0-alpine3.13
 
 MAINTAINER MoJ Digital, Probation in Court <probation-in-court-team@digital.justice.gov.uk>
 ARG BUILD_NUMBER

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Prepare a case is a service that allows probation staff to prepare court cases.
 
 ## Prerequisities
 Before you begin, ensure you have met the following requirements:
-* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Fermium) >= v14.16.1
+* You have Node.js [LTS](https://nodejs.org/en/about/releases/) (Fermium) >= v14.17.0
 
 For code quality the project adheres to [JavaScript Standard Style](https://standardjs.com/) which requires minimal configuration of your chosen IDE.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2287,9 +2287,9 @@
       }
     },
     "@ministryofjustice/frontend": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.2.3.tgz",
-      "integrity": "sha512-Q+He/iB+GxWn4QpFwZCMQ5n22hmrmZaMRWkuE1fH1+jlQr/s6pdjzTE2dsD7ff0BccIHrAK5wb3lFdRdlZlsMw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-0.2.4.tgz",
+      "integrity": "sha512-KmDTogrU0cDBs7Mwa/v2I5jHEdeV67oyHohX2MezQCC8HZnCFh5ZtqYPsdXd3fj0Smb/H9m5NHv5wdWPNkLkrA==",
       "requires": {
         "moment": "^2.27.0"
       }
@@ -3143,9 +3143,9 @@
       }
     },
     "ajv": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.3.0.tgz",
-      "integrity": "sha512-RYE7B5An83d7eWnDR8kbdaIFqmKCNsP16ay1hDbJEU+sa0e3H9SebskCt0Uufem6cfAVu7Col6ubcn/W+Sm8/Q==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
+      "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -3587,9 +3587,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.0.tgz",
-      "integrity": "sha512-1uIESzroqpaTzt9uX48HO+6gfnKu3RwvWdCcWSrX4csMInJfCo1yvKPNXCwXFRpJqRW25tiASb6No0YH57PXqg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.1.tgz",
+      "integrity": "sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==",
       "dev": true
     },
     "axios": {
@@ -7941,9 +7941,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
-      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
+      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA=="
     },
     "graceful-fs": {
       "version": "4.2.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/ministryofjustice/prepare-a-case.git"
   },
   "engines": {
-    "node": ">=14.16.1 <15.0.0"
+    "node": ">=14.17.0 <15.0.0 || >=16.2.0"
   },
   "scripts": {
     "precommit": "npm run lint && npm run unit-test && npm run int-test",
@@ -69,7 +69,7 @@
     "stepDefinitions": "integration-tests/integration/"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "0.2.3",
+    "@ministryofjustice/frontend": "0.2.4",
     "accessible-autocomplete": "2.0.3",
     "agentkeepalive": "4.1.4",
     "applicationinsights": "2.0.0",
@@ -87,7 +87,7 @@
     "dotenv": "9.0.2",
     "express": "4.17.1",
     "express-session": "1.17.1",
-    "govuk-frontend": "3.11.0",
+    "govuk-frontend": "3.12.0",
     "helmet": "4.6.0",
     "jsonwebtoken": "8.5.1",
     "jwt-decode": "3.1.2",
@@ -103,9 +103,9 @@
   "devDependencies": {
     "@cucumber/cucumber": "7.2.1",
     "@pact-foundation/pact": "9.15.5",
-    "ajv": "8.3.0",
+    "ajv": "8.4.0",
     "ajv-errors": "3.0.0",
-    "axe-core": "4.2.0",
+    "axe-core": "4.2.1",
     "cypress": "7.3.0",
     "cypress-axe": "0.12.2",
     "cypress-cucumber-preprocessor": "4.1.0",


### PR DESCRIPTION
⬆️ Updated to use Node 14.17.0
⬆️ ajv 8.3.0  →   8.4.0
⬆️ axe-core 4.2.0  →   4.2.1
⬆️ @ministryofjustice/frontend 0.2.3  →   0.2.4
⬆️ govuk-frontend 3.11.0  →  3.12.0

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>