### PR TITLE
PIC-1204 Underscore in probation status on manual matching screen

### DIFF
--- a/mappings/matching/probation-status-detail/default-probation-status-detail.json
+++ b/mappings/matching/probation-status-detail/default-probation-status-detail.json
@@ -10,7 +10,7 @@
     },
     "status": 200,
     "jsonBody": {
-      "status": "CURRENT",
+      "status": "PREVIOUSLY_KNOWN",
       "inBreach": true,
       "preSentenceActivity": true,
       "previouslyKnownTerminationDate": "{{now offset='-6 months' format='yyyy-MM-dd'}}"

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -474,7 +474,7 @@ module.exports = function Index ({ authenticationMiddleware }) {
     templateValues.title = 'Link an NDelius record to the defendant'
     templateValues.details = {
       ...detailResponse,
-      probationStatus: probationStatusDetails.status
+      probationStatus: probationStatusDetails.status.replace('_', ' ')
     }
     templateValues.session = {
       ...session

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -474,7 +474,7 @@ module.exports = function Index ({ authenticationMiddleware }) {
     templateValues.title = 'Link an NDelius record to the defendant'
     templateValues.details = {
       ...detailResponse,
-      probationStatus: probationStatusDetails.status.replace('_', ' ')
+      probationStatus: probationStatusDetails.status && probationStatusDetails.status.replace('_', ' ')
     }
     templateValues.session = {
       ...session


### PR DESCRIPTION
🐛 Removed underscore in display of probation status on manual matching screen

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>