### PR TITLE
:white_check_mark: PIC-1439: removed pssRequirements data

### DIFF
--- a/tests/pact/community-service/get-probation-record.test.pact.json
+++ b/tests/pact/community-service/get-probation-record.test.pact.json
@@ -85,18 +85,7 @@
               }
             }
           ],
-          "pssRequirements": [
-            {
-              "description": "Standard 7 conditions"
-            },
-            {
-              "description": "Specified Activity",
-              "subTypeDescription": "ETE - High intensity"
-            },
-            {
-              "description": "Curfew Arrangement"
-            }
-          ],
+          "pssRequirements": [],
           "licenceConditions": [
             {
               "description": "Curfew Arrangement",


### PR DESCRIPTION
Removed the pssRequirements data to fix PACT, this isn't expected to return data in court-case-service when returning requirements and licenceConditions