### PR TITLE
End-of-line normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+*.md text
+*.scss text
+*.css text
+*.js text
+*.json text
+*.njk text
+*.htm text
+*.html text
+*.feature text
+*.txt text
+*.sh text
+*.yaml text
+*.yml text


### PR DESCRIPTION
This should enforce text end-of-line on all relevant files.

🔧 Introduce end-of-line normalization

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>