### PR TITLE
🔥 Unhide author on probation record page

### DIFF
--- a/server/views/case-summary-record.njk
+++ b/server/views/case-summary-record.njk
@@ -78,7 +78,7 @@
               {{ psrData.courtReportType.description }}
             </dd>
           </div>
-          <div class="govuk-summary-list__row moj-hidden">
+          <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
               Author
             </dt>


### PR DESCRIPTION
The author is now being populated correctly so this will show it again