### PR TITLE
PIC-1595 Increase timeouts

### DIFF
--- a/config.js
+++ b/config.js
@@ -19,8 +19,8 @@ const requiredInProduction = { requireInProduction: true }
 
 module.exports = {
   settings: {
-    defaultTimeout: 2000,
-    healthTimeout: 1000,
+    defaultTimeout: 4000,
+    healthTimeout: 2000,
     casesPerPage: get('CASES_PER_PAGE', 20),
     casesTotalDays: get('CASES_TOTAL_DAYS', 7),
     casesExcludedDays: get('CASES_EXCLUDED_DAYS', '0'), // Coma delimited String of days to exclude, incremental from 0 (Sunday)


### PR DESCRIPTION
After discussing with John, we've determined that the cause of the ClientAbortException alert could be that the backend has not yet responded due to a delay in the community API before the frontend times out.

We have agreed that a 4 second timeout should be acceptable for both handling a delay and not causing too much of a disruption to the user experience when a delay occurs.

🔧 Adjusted timeouts

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>