### PR TITLE
fix: the case filter list fails when no cases come in.

### DIFF
--- a/server/utils/getCaseListFilters.js
+++ b/server/utils/getCaseListFilters.js
@@ -1,6 +1,8 @@
 const { getNormalisedCourtRoom } = require('../routes/helpers')
 
 module.exports = (caseListData, selectedFilters) => {
+  caseListData ||= []
+
   const availableProbationStatuses = [...new Set(caseListData.map(item => item.probationStatus))]
   const probationStatuses = []
   const statusOrder = ['Current', 'Pre-sentence record', 'Previously known', 'No record', 'Possible NDelius record']


### PR DESCRIPTION
This is because the endpoint is changing its schema return when there's no data rather than giving an empty array. I didn't change it there as there's several other bits of code handling the same behaviour.