### PR TITLE
fix: Pass defendantId along with hearingId to the mass action feature

### DIFF
--- a/server/routes/handlers/outcomes/postActionsHandler.js
+++ b/server/routes/handlers/outcomes/postActionsHandler.js
@@ -5,18 +5,19 @@ module.exports = caseService => async (req, res) => {
   const {
     body: {
       action,
-      hearingId
+      defendantHearingId
     },
     session
   } = req
 
-  let items
+  const items = (typeof defendantHearingId === 'string' ? [defendantHearingId] : defendantHearingId)
+    .map(defendantHearingId => defendantHearingId.split('_'))
 
   switch (action) {
     case 'assign':
-      items = typeof hearingId === 'string' ? [hearingId] : hearingId
       await Promise.all(items
-        .map(hearingId => caseService.assignHearingOutcome(hearingId, res.locals.user.name)))
+        // WARN: the defendantID should be consumed by this function - backend bug!
+        .map(([defendantId, hearingId]) => caseService.assignHearingOutcome(hearingId, res.locals.user.name)))
       session.outcomeActionAssign = items.length
       delete req.body
       return casesToResultHandler(req, res)

--- a/server/views/outcomes/casesToResult.njk
+++ b/server/views/outcomes/casesToResult.njk
@@ -69,11 +69,11 @@
   {% set summaryLink = '/' + params.courtCode + '/hearing/' + item.hearingId + '/defendant/' + item.defendantId + '/summary' %}
   {%- set tableRow = [
     { html: govukCheckboxes({
-      name: "hearingId",
+      name: "defendantHearingId",
       classes: "common_checker_toggle_item govuk-checkboxes--small",
       items: [{
-        id: "id-" + item.hearingId,
-        value: item.hearingId,
+        id: "id_" + item.defendantId + '_' + item.hearingId,
+        value: item.defendantId + '_' + item.hearingId,
         html: " "
       }]}) 
     },


### PR DESCRIPTION
Note the defendantId isn't consumed by the outcome assign function, a bug which existed prior to mass action being implemented and which has just come to light.