### PR TITLE
Update notification banner to use nunjucks filters for names

### DIFF
--- a/server/views/outcomes/casesInProgress.njk
+++ b/server/views/outcomes/casesInProgress.njk
@@ -117,7 +117,7 @@
     {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
     {% set html %}
       <p class="govuk-notification-banner__heading">
-        You have moved {{ moveToResultedSuccess }}'s case to resulted cases.
+        You have moved {{ moveToResultedSuccess | apostropheInName | properCase | removeTitle }}'s case to resulted cases.
       </p>
     {% endset %}
     {{ govukNotificationBanner({


### PR DESCRIPTION
When assigning a single case during mass assign the name was not following formatting standards set elsewhere on the page