### PR TITLE
fix: if auth fires a 401/403 (should only be a 403) then the user is …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "applicationinsights": "2.9.2",
         "applicationinsights-native-metrics": "0.0.10",
         "axios": "1.1.0",
-        "axios-middleware": "0.4.0",
         "bootstrap": "^5.3.2",
         "bunyan": "1.8.15",
         "bunyan-format": "0.2.1",
@@ -2538,17 +2537,6 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-middleware": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/axios-middleware/-/axios-middleware-0.4.0.tgz",
-      "integrity": "sha512-neL0nV9oZoSM0gjxLTvF6VpypElTFcEfLPRBLgeoSxKuHroNtJOAnBoFX2VNU/FefgDNmW62nhylq6T/kNAeYg==",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "axios": ">=0.17.1 <1.2.0"
       }
     },
     "node_modules/babel-jest": {
@@ -12609,12 +12597,6 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
-    },
-    "axios-middleware": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/axios-middleware/-/axios-middleware-0.4.0.tgz",
-      "integrity": "sha512-neL0nV9oZoSM0gjxLTvF6VpypElTFcEfLPRBLgeoSxKuHroNtJOAnBoFX2VNU/FefgDNmW62nhylq6T/kNAeYg==",
-      "requires": {}
     },
     "babel-jest": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "applicationinsights": "2.9.2",
     "applicationinsights-native-metrics": "0.0.10",
     "axios": "1.1.0",
-    "axios-middleware": "0.4.0",
     "bootstrap": "^5.3.2",
     "bunyan": "1.8.15",
     "bunyan-format": "0.2.1",

--- a/server/errorHandler.js
+++ b/server/errorHandler.js
@@ -9,6 +9,14 @@ exports.notFound = (req, res, next) => {
   next(error)
 }
 
+exports.authError = (error, req, res, next) => {
+  if ([401, 403]
+    .includes(error.status)) {
+    return res.redirect('/logout')
+  }
+  next(error)
+}
+
 exports.developmentErrors = (error, req, res, next) => {
   logger.error(error)
   error.stack = error.stack || ''

--- a/server/routes/middleware/authorisationMiddleware.js
+++ b/server/routes/middleware/authorisationMiddleware.js
@@ -8,7 +8,7 @@ module.exports = (req, res, next) => {
     const { authorities: roles, name, user_id: userId, user_uuid: uuid, user_name: username } = jwtDecode(res.locals.user.token)
     Object.assign(res.locals.user, { name, uuid, username, userId })
     if (!roles.includes(config.apis.oauth2.role)) {
-      log.warn(`User does not have required role ${config.apis.oauth2.role}`)
+      log.warn(`User does not have required role ${config.apis.oauth2.role}. Ensure Delius user has role 'CWBT200'.`)
       return res.redirect('/autherror')
     }
     return next()


### PR DESCRIPTION
…logged out and redirected to reauth. This replaces token refresh which as deprecated and removed (it never worked) from PAC.