### PR TITLE
[do not merge] PIC-2389: Update PACT tests for case comments feature

### DIFF
--- a/schemas/post-case-comment-schema.schema.json
+++ b/schemas/post-case-comment-schema.schema.json
@@ -7,7 +7,8 @@
   "required": [
     "author",
     "comment",
-    "caseId"
+    "caseId",
+    "defendantId"
   ],
   "properties": {
     "author": {
@@ -28,6 +29,13 @@
       "$id": "#/properties/caseComments/items/anyOf/0/properties/caseId",
       "type": "string",
       "title": "The case id",
+      "description": "An explanation about the purpose of this instance.",
+      "default": ""
+    },
+    "defendantId": {
+      "$id": "#/properties/caseComments/items/anyOf/0/properties/defendantId",
+      "type": "string",
+      "title": "The defendant id",
       "description": "An explanation about the purpose of this instance.",
       "default": ""
     },

--- a/tests/pact/case-service/create-comment.test.pact.js
+++ b/tests/pact/case-service/create-comment.test.pact.js
@@ -5,10 +5,12 @@ const { validateSchema, validateMocks } = require('../../testUtils/schemaValidat
 const schema = require('../../../schemas/post-case-comment-schema.schema.json')
 
 pactWith({ consumer: 'prepare-a-case', provider: 'court-case-service' }, provider => {
-  describe('POST /cases/{caseId}/comments', () => {
+  describe('POST /cases/{caseId}/defendants/{defendantId}/comments', () => {
     const caseId = 'f76f1dfe-c41e-4242-b5fa-865d7dd2ce57'
+    const defendantId = '062c670d-fdf6-441f-99e1-d2ce0c3a3846'
     const requestBody = {
       caseId,
+      defendantId,
       comment: 'A comment',
       author: 'Adam Sandler'
     }
@@ -29,11 +31,11 @@ pactWith({ consumer: 'prepare-a-case', provider: 'court-case-service' }, provide
         commentId: 12234
       }
       await provider.addInteraction({
-        state: 'a case exists with the given case id',
+        state: 'a case exists with the given case id and defendant id',
         uponReceiving: 'a request to create a case comment',
         withRequest: {
           method: 'POST',
-          path: `/cases/${caseId}/comments`,
+          path: `/cases/${caseId}/defendants/${defendantId}/comments`,
           headers: {
             'Content-Type': 'application/json'
           },
@@ -49,7 +51,7 @@ pactWith({ consumer: 'prepare-a-case', provider: 'court-case-service' }, provide
       })
 
       const caseService = createCaseService(provider.mockService.baseUrl)
-      const response = await caseService.addCaseComment(caseId, 'A comment', 'Adam Sandler')
+      const response = await caseService.addCaseComment(caseId, defendantId, 'A comment', 'Adam Sandler')
       expect(response.status).toEqual(201)
       expect(response.data).toEqual(addCommentResponse)
     })

--- a/tests/pact/case-service/delete-case-comment.test.pact.js
+++ b/tests/pact/case-service/delete-case-comment.test.pact.js
@@ -21,7 +21,7 @@ pactWith({ consumer: 'prepare-a-case', provider: 'court-case-service' }, provide
       })
 
       const service = createCaseService(provider.mockService.baseUrl)
-      const response = await service.deleteCaseComment(caseId,defendantId, 1234)
+      const response = await service.deleteCaseComment(caseId, defendantId, 1234)
       expect(response.status).toEqual(200)
     })
   })

--- a/tests/pact/case-service/delete-case-comment.test.pact.js
+++ b/tests/pact/case-service/delete-case-comment.test.pact.js
@@ -4,13 +4,16 @@ const { createCaseService } = require('../../../server/services/case-service')
 
 pactWith({ consumer: 'prepare-a-case', provider: 'court-case-service' }, provider => {
   describe('DELETE /cases/{caseId}/comments/{commentId}', () => {
-    it('deletes the case comment with given case id and comment id', async () => {
+    const caseId = 'f76f1dfe-c41e-4242-b5fa-865d7dd2ce57'
+    const defendantId = '062c670d-fdf6-441f-99e1-d2ce0c3a3846'
+
+    it('deletes the case comment with given case id, defendant id and comment id', async () => {
       await provider.addInteraction({
-        state: 'a case exists with the given case id',
+        state: 'a case exists with the given case id and defendant id',
         uponReceiving: 'a request to delete a comment on a case',
         withRequest: {
           method: 'DELETE',
-          path: '/cases/f76f1dfe-c41e-4242-b5fa-865d7dd2ce57/comments/1234'
+          path: `/cases/${caseId}/defendants/${defendantId}/comments/1234`
         },
         willRespondWith: {
           status: 200
@@ -18,7 +21,7 @@ pactWith({ consumer: 'prepare-a-case', provider: 'court-case-service' }, provide
       })
 
       const service = createCaseService(provider.mockService.baseUrl)
-      const response = await service.deleteCaseComment('f76f1dfe-c41e-4242-b5fa-865d7dd2ce57', 1234)
+      const response = await service.deleteCaseComment(caseId,defendantId, 1234)
       expect(response.status).toEqual(200)
     })
   })

--- a/wiremock/mappings/court-case-service/case-comments/create-comment.json
+++ b/wiremock/mappings/court-case-service/case-comments/create-comment.json
@@ -2,12 +2,13 @@
   "id": "e5552927-3236-42c2-8d3c-508b7a1e53f0",
   "request": {
     "method": "PUT",
-    "urlPathPattern": "/cases/e5552927-3236-42c2-8d3c-508b7a1e53f0/comments",
+    "urlPathPattern": "/cases/e5552927-3236-42c2-8d3c-508b7a1e53f0/defendants/062c670d-fdf6-441f-99e1-d2ce0c3a3846/comments",
     "bodyPatterns": [
       {
         "equalToJson": {
           "author": "${json-unit.any-string}",
           "caseId": "f76f1dfe-c41e-4242-b5fa-865d7dd2ce57",
+          "defendantId": "062c670d-fdf6-441f-99e1-d2ce0c3a3846",
           "comment": "${json-unit.any-string}"
         }
       }


### PR DESCRIPTION
## Update the Pact tests for case comments

- Update the endpoints for creating a case comment in the pact tests

This is because court case service and this service uses the endpoint `/cases/:id/defendants/:id/comments`
rather than `/cases/:id/comments`

This change should fix the PACT tests

**Additional information:**
This works on top of the previous PR
https://github.com/ministryofjustice/prepare-a-case/pull/658


## TO DO:
- [ ] Uncomment out pact_push from CI/CD
- [ ] Fix broken PACT tests or migrate to something else