### PR TITLE
Increase default timeout to 20 seconds

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -23,7 +23,7 @@ const getCsvParamAsArray = param => get(param, '')?.split(',').map(value => valu
 
 module.exports = {
   settings: {
-    defaultTimeout: get('DEFAULT_TIMEOUT', 6000),
+    defaultTimeout: get('DEFAULT_TIMEOUT', 20000),
     healthTimeout: 2000,
     reduceStdoutNoise: get('REDUCE_STDOUT_NOISE', false),
     casesPerPage: get('CASES_PER_PAGE', 20),


### PR DESCRIPTION
Currently users are experiencing timeouts with their average timing taking 8.5 seconds.

Increase the timeout to 20 seconds as a temporary patch until we resolve our performance issues.