### PR TITLE
Check for things in common with BE

### DIFF
--- a/server/routes/handlers/caseSummary.js
+++ b/server/routes/handlers/caseSummary.js
@@ -131,7 +131,8 @@ const moveToResulted = async (res, req, utils, templateValues) => {
       courtCode,
       defendantId,
       correlationId,
-      userId: res.locals.user.uuid
+      userId: res.locals.user.uuid,
+      user: res.locals.user
     }
   )
 

--- a/server/routes/handlers/outcomes/getMoveToResultedHandler.js
+++ b/server/routes/handlers/outcomes/getMoveToResultedHandler.js
@@ -14,7 +14,8 @@ const getMoveToResultedHandler = caseService => async (req, res) => {
       courtCode,
       defendantId,
       correlationId,
-      userId: res.locals.user.uuid
+      userId: res.locals.user.uuid,
+      user: res.locals.user
     }
   )
 


### PR DESCRIPTION
To get to the bottom of the mismatch of the uuid within the resulting call more logging is required for the event around the POST request. This will be removed once investigation is complete.