### PR TITLE
PIC-4268: Setting the minimum match probability to zero, so that all records are displayed

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -42,7 +42,7 @@ module.exports = {
     scriptCache: '24h',
     matchingRecordsToBeShownPerPage: 5,
     maximumPages: 4,
-    minimumMatchProbability: 0.5,
+    minimumMatchProbability: 0.0,
     caseSearchResultPageSize: get('CASE_SEARCH_PAGE_SIZE', 20),
     hearingOutcomesPageSize: get('HEARING_OUTCOMES_PAGE_SIZE', 20),
     availableCourts: [


### PR DESCRIPTION
Setting the minimum match probability to zero, so that all the matching records are displayed and not filtered based on the filtration criteria. The displyed records are still sorted and paginated