### PR TITLE
PIC-4268: Setting the minimum match probability to zero

### DIFF
--- a/integration-tests/cypress/e2e/matching.feature
+++ b/integration-tests/cypress/e2e/matching.feature
@@ -1,3 +1,4 @@
+#***
 Feature: Matching defendants to nDelius records
   In order to match defendants to probation records
   As an authenticated user
@@ -47,7 +48,7 @@ Feature: Matching defendants to nDelius records
     And I should see the inset text "Details that match the defendant are highlighted."
 
     Then I should see the level 3 heading "Defendant details"
-    And I should see the legend "6 possible NDelius records"
+    And I should see the legend "10 possible NDelius records"
 
     And I should see the following table headings
       | Name | Date of birth | Address | PNC |

--- a/integration-tests/cypress/e2e/matching.feature
+++ b/integration-tests/cypress/e2e/matching.feature
@@ -1,4 +1,3 @@
-#***
 Feature: Matching defendants to nDelius records
   In order to match defendants to probation records
   As an authenticated user

--- a/server/config.js
+++ b/server/config.js
@@ -42,7 +42,6 @@ module.exports = {
     scriptCache: '24h',
     matchingRecordsToBeShownPerPage: 5,
     maximumPages: 4,
-    minimumMatchProbability: 0.5,
     caseSearchResultPageSize: get('CASE_SEARCH_PAGE_SIZE', 20),
     hearingOutcomesPageSize: get('HEARING_OUTCOMES_PAGE_SIZE', 20),
     enableMatcherLogging: getBooleanParam('ENABLE_MATCHER_LOGGING'),

--- a/server/services/case-service.js
+++ b/server/services/case-service.js
@@ -42,15 +42,13 @@ const createCaseService = apiUrl => {
       // Sort offenderMatchDetails based on matchProbability in descending order
       if (Array.isArray(res.data.offenderMatchDetails)) {
         res.data.offenderMatchDetails.sort((a, b) => {
-          const probA = parseFloat(a.matchProbability ?? 0)
-          const probB = parseFloat(b.matchProbability ?? 0)
+          const probA = (a.matchProbability != null && !isNaN(parseFloat(a.matchProbability)))
+            ? parseFloat(a.matchProbability)
+            : 0
+          const probB = (b.matchProbability != null && !isNaN(parseFloat(b.matchProbability)))
+            ? parseFloat(b.matchProbability)
+            : 0
           return probB - probA // Descending order
-        })
-
-        // Filter out details where matchProbability is less than settings.minimumMatchProbability
-        res.data.offenderMatchDetails = res.data.offenderMatchDetails.filter(detail => {
-          const matchProb = parseFloat(detail.matchProbability ?? 0)
-          return matchProb >= parseFloat(settings.minimumMatchProbability)
         })
       } else {
         res.data.offenderMatchDetails = []

--- a/server/services/case-service.js
+++ b/server/services/case-service.js
@@ -42,10 +42,10 @@ const createCaseService = apiUrl => {
       // Sort offenderMatchDetails based on matchProbability in descending order
       if (Array.isArray(res.data.offenderMatchDetails)) {
         res.data.offenderMatchDetails.sort((a, b) => {
-          const probA = (a.matchProbability != null && !isNaN(parseFloat(a.matchProbability)))
+          const probA = !isNaN(parseFloat(a.matchProbability))
             ? parseFloat(a.matchProbability)
             : 0
-          const probB = (b.matchProbability != null && !isNaN(parseFloat(b.matchProbability)))
+          const probB = !isNaN(parseFloat(b.matchProbability))
             ? parseFloat(b.matchProbability)
             : 0
           return probB - probA // Descending order

--- a/tests/services/case-service.test.js
+++ b/tests/services/case-service.test.js
@@ -359,7 +359,7 @@ describe('Case service', () => {
     return response
   })
 
-  it('should sort offenderMatchDetails by matchProbability in descending order and filter out entry lesser than 0.5', async () => {
+  it('should sort offenderMatchDetails by matchProbability in descending order and NOT filter out any entry', async () => {
     const endpoint = `${apiUrl}/defendant/2e0afeb7-95d2-42f4-80e6-ccf96b282730/matchesDetail`
     moxios.stubRequest(endpoint, {
       status: 200,
@@ -368,7 +368,7 @@ describe('Case service', () => {
           { matchProbability: 0.8 },
           { matchProbability: 0.9 },
           { matchProbability: 0.7 },
-          { matchProbability: 0.2 } // filtered out
+          { matchProbability: 0.2 }
         ]
       }
     })
@@ -377,69 +377,9 @@ describe('Case service', () => {
     expect(response.offenderMatchDetails).toEqual([
       { matchProbability: 0.9 },
       { matchProbability: 0.8 },
-      { matchProbability: 0.7 }
-    ])
-  })
-
-  it('should filter offenderMatchDetails with matchProbability less than settings.minimumMatchProbability', async () => {
-    settings.minimumMatchProbability = 0.5
-
-    const endpoint = `${apiUrl}/defendant/2e0afeb7-95d2-42f4-80e6-ccf96b282730/matchesDetail`
-    moxios.stubRequest(endpoint, {
-      status: 200,
-      response: {
-        offenderMatchDetails: [
-          { matchProbability: 0.4 },
-          { matchProbability: 0.7 },
-          { matchProbability: 0.5 }
-        ]
-      }
-    })
-
-    const response = await getMatchDetails('2e0afeb7-95d2-42f4-80e6-ccf96b282730')
-    expect(response.offenderMatchDetails).toEqual([
       { matchProbability: 0.7 },
-      { matchProbability: 0.5 }
+      { matchProbability: 0.2 }
     ])
-  })
-
-  it('should handle undefined or null matchProbability values as 0', async () => {
-    settings.minimumMatchProbability = 0.5
-
-    const endpoint = `${apiUrl}/defendant/2e0afeb7-95d2-42f4-80e6-ccf96b282730/matchesDetail`
-    moxios.stubRequest(endpoint, {
-      status: 200,
-      response: {
-        offenderMatchDetails: [
-          { matchProbability: undefined },
-          { matchProbability: null },
-          { matchProbability: 0.7 }
-        ]
-      }
-    })
-
-    const response = await getMatchDetails('2e0afeb7-95d2-42f4-80e6-ccf96b282730')
-    expect(response.offenderMatchDetails).toEqual([
-      { matchProbability: 0.7 }
-    ])
-  })
-
-  it('should return an empty array if no offenderMatchDetails meet the minimumMatchProbability', async () => {
-    settings.minimumMatchProbability = 0.8
-
-    const endpoint = `${apiUrl}/defendant/2e0afeb7-95d2-42f4-80e6-ccf96b282730/matchesDetail`
-    moxios.stubRequest(endpoint, {
-      status: 200,
-      response: {
-        offenderMatchDetails: [
-          { matchProbability: 0.2 },
-          { matchProbability: 0.5 }
-        ]
-      }
-    })
-
-    const response = await getMatchDetails('2e0afeb7-95d2-42f4-80e6-ccf96b282730')
-    expect(response.offenderMatchDetails).toEqual([])
   })
 
   it('should return an empty array if offenderMatchDetails is not an array', async () => {
@@ -479,28 +419,6 @@ describe('Case service', () => {
 
     const response = await getMatchDetails('2e0afeb7-95d2-42f4-80e6-ccf96b282730')
     expect(response.offenderMatchDetails).toEqual([])
-  })
-
-  it('should treat invalid matchProbability values inside offenderMatchDetails as 0', async () => {
-    settings.minimumMatchProbability = 0.5
-
-    const endpoint = `${apiUrl}/defendant/2e0afeb7-95d2-42f4-80e6-ccf96b282730/matchesDetail`
-    moxios.stubRequest(endpoint, {
-      status: 200,
-      response: {
-        offenderMatchDetails: [
-          { matchProbability: 'invalid' }, // invalid string
-          { matchProbability: {} }, // invalid object
-          { matchProbability: [] }, // invalid array
-          { matchProbability: 0.6 }
-        ]
-      }
-    })
-
-    const response = await getMatchDetails('2e0afeb7-95d2-42f4-80e6-ccf96b282730')
-    expect(response.offenderMatchDetails).toEqual([
-      { matchProbability: 0.6 } // Only valid matchProbability values remain
-    ])
   })
 
   it('should return an empty array if offenderMatchDetails is null or undefined', async () => {


### PR DESCRIPTION
Setting the minimum match probability to zero, so that all the matching records are displayed and not filtered based on the filtration criteria.