### PR TITLE
PIC-3141: Capitalise case list acronyms

### DIFF
--- a/integration-tests/cypress/e2e/case-list.feature
+++ b/integration-tests/cypress/e2e/case-list.feature
@@ -31,10 +31,14 @@ Feature: Case list
     And I should see the following table headings
       | Defendant | Probation status | Offence | Listing | Session | Court |
 
-    And I should see the following table rows
-      | Kara Ayers     | No record                 | Attempt theft from the person of another | 1st | Morning | Crown Court 3-1 |
-      | Mann Carroll   | {Psr} Pre-sentence record | Assault by beating                       | 3rd | Morning | 2               |
-      | Guadalupe Hess | {Possible}                | Assault by beating                       |     | Morning | Crown Court 3-1 |
+    And I should see the following table rows by row index
+      | 0  | Kara Ayers       | No record                 | Attempt theft from the person of another | 1st | Morning   | Crown Court 3-1 |
+      | 1  | Mann Carroll     | {PSR} Pre-sentence record | Assault by beating                       | 3rd | Morning   | 2               |
+      | 2  | Guadalupe Hess   | {Possible}                | Assault by beating                       |     | Morning   | Crown Court 3-1 |
+      | 3  | Charlene Hammond | Previously known          | Theft from the person of another         | 3rd | Afternoon | 10              |
+      | 10 | Olsen Alexander  | {SSO} Current             | Theft from a shop                        | 2nd | Morning   | 2               |
+      | 11 | English Madden   | {Breach} Current          | Attempt theft from the person of another | 2nd | Morning   | 6               |
+
 
     And I should see link "Kara Ayers" with href "/hearing/5b9c8c1d-e552-494e-bc90-d475740c64d8/defendant/8597a10b-d330-43e5-80c3-27ce3b46979f/summary"
     And I should see link "Mann Carroll" with href "/hearing/a395526d-b805-4c52-8f61-3c41bca15537/defendant/d1d38809-af04-4ff0-9328-4db39c0a3d85/summary"

--- a/integration-tests/cypress/support/step_definitions/common.js
+++ b/integration-tests/cypress/support/step_definitions/common.js
@@ -208,6 +208,34 @@ Then('I should see the following table rows', $data => {
   })
 })
 
+Then('I should see the following table rows by row index', $data => {
+  $data.raw().forEach((tableRow) => {
+    const tableRowIndex = tableRow[0]
+    const rowData = tableRow.slice(1)
+    rowData.forEach((text, colIndex) => {
+      cy.get('.govuk-table__body > .govuk-table__row').eq(Number(tableRowIndex)).within(() => {
+          if (!text) {
+            return
+          }
+          const safeText = text.split(' ').map(part => {
+            if (part.includes('{')) {
+              cy.get('.govuk-table__cell').eq(colIndex).within(() => {
+                cy.get('.pac-badge').contains(part.replace(/{|}|/g, '')).should('exist')
+              })
+              return undefined
+            } else {
+              return part
+            }
+          })
+          const checkText = safeText.join(' ').trim()
+          if (checkText !== '') {
+            cy.get('.govuk-table__cell').eq(colIndex).contains(correctDates(checkText).replaceAll(' \n ', ''))
+          }
+        })
+      })
+    })
+  })
+
 Then('I should see the following table {int} rows', ($int, $data) => {
   cy.get('.govuk-table').eq($int - 1).within(() => {
     $data.raw().forEach((row, index) => {

--- a/server/utils/caseListTableData.js
+++ b/server/utils/caseListTableData.js
@@ -11,7 +11,7 @@ const getBadge = (item, notMatched) => {
   }
 
   if (item.awaitingPsr) {
-    badgeText = 'Psr'
+    badgeText = 'PSR'
   }
 
   if (item.breach) {
@@ -19,7 +19,7 @@ const getBadge = (item, notMatched) => {
   }
 
   if (item.suspendedSentenceOrder) {
-    badgeText = 'Sso'
+    badgeText = 'SSO'
   }
 
   return badgeText ? `<div><span class="moj-badge moj-badge--${badgeColour} pac-badge">${badgeText}</span></div>` : ''


### PR DESCRIPTION
Capitalise acronyms to encourage them to be read as such, expand case-list tests to cover these badges.

This requires some follow up testing, particularly with JAWS which is not available on macOS but there is some follow up thinking about what to follow up anything else as "how acronyms are read" has as much to do with, if not more, with the screen readers settings.