### PR TITLE
PIC 3142: Case summary information hierarchy

### DIFF
--- a/integration-tests/cypress/e2e/case-progress.feature
+++ b/integration-tests/cypress/e2e/case-progress.feature
@@ -13,7 +13,7 @@ Feature: Case progress
     Then I should be on the "Case summary" page
     And I should see the caption text "URN: 01WW0298121"
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And I should see 6 previous hearings headers
     And I should see "Expand to add a hearing note" link on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
 
@@ -37,7 +37,7 @@ Feature: Case progress
       | Date of birth | 31 October 1980 (41 years old)                                        |
       | Address       | 22 Waldorf Court Cardiff AD21 5DR                                     |
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And I should see 6 previous hearings headers
 
     And I should see the following hearings with the hearing type label, hearing details and next appearance badge if applicable
@@ -88,7 +88,7 @@ Feature: Case progress
       | Date of birth | 31 October 1980 (41 years old)                                        |
       | Address       | 22 Waldorf Court Cardiff AD21 5DR                                     |
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And I should see 6 previous hearings headers
 
     When I click delete hearing note with id "1288880" on hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e3"
@@ -127,7 +127,7 @@ Feature: Case progress
       | Date of birth | 31 October 1980 (41 years old)                                        |
       | Address       | 22 Waldorf Court Cardiff AD21 5DR                                     |
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And I should see 6 previous hearings headers
     And I should see below notes on hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e7" with author datetime and note with edit and delete links
       | John Doe    | 9 August 2022, 17:16  | Result: 6 months Community Order 10 RAR UPW - 50hrs court costs induction required at local office.   |
@@ -145,7 +145,7 @@ Feature: Case progress
     And I should see back link "Back to cases" with href "/B14LO/cases/$TODAY"
     And I should see the caption text "URN: 01WW0298121"
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And I should "see" line breaks on hearing note "754270"
 
   Scenario: Display hearing notes without line breaks
@@ -158,6 +158,6 @@ Feature: Case progress
     And I should see back link "Back to cases" with href "/B14LO/cases/$TODAY"
     And I should see the caption text "URN: 01WW0298121"
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And I should "not see" line breaks on hearing note "987650"
 

--- a/integration-tests/cypress/e2e/case-summary-hearing-outcome.feature
+++ b/integration-tests/cypress/e2e/case-summary-hearing-outcome.feature
@@ -20,7 +20,7 @@ Feature: Case progress - Hearing outcome
       | Date of birth | 31 October 1980 (41 years old)                                        |
       | Address       | 22 Waldorf Court Cardiff AD21 5DR                                     |
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e7" should have hearing outcome "Adjourned" sent to admin on "Monday 24 April 2023"
     And hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e5" should have hearing outcome "Report requested" sent to admin on "Tuesday 9 May 2023"
 
@@ -32,7 +32,7 @@ Feature: Case progress - Hearing outcome
     When I navigate to the "/B14LO/hearing/5b9c8c1d-e552-494e-bc90-d475740c64d8/defendant/8597a10b-d330-43e5-80c3-27ce3b46979f/summary" base route
     Then I should be on the "Case summary" page
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e3" should have button "Send outcome to admin"
     And hearing "1f93aa0a-7e46-4885-a1cb-f25a4be33a00" should have button "Send outcome to admin"
 
@@ -103,7 +103,7 @@ Feature: Case progress - Hearing outcome
     When I navigate to the "/B14LO/hearing/9b9a6ab6-ef6d-485a-a8b4-b79b67e5b1f8/defendant/82bfc40d-389a-46ba-81e1-0829a5fbf6c8/summary" base route
     Then I should be on the "Case summary" page
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And hearing "1f93aa0a-7e46-4885-a1cb-f25a4be33a10" should not have link "Edit"
 
   Scenario: Edit hearing outcome modal popup
@@ -114,7 +114,7 @@ Feature: Case progress - Hearing outcome
     When I navigate to the "/B14LO/hearing/5b9c8c1d-e552-494e-bc90-d475740c64d8/defendant/8597a10b-d330-43e5-80c3-27ce3b46979f/summary" base route
     Then I should be on the "Case summary" page
 
-    And I should see the level 2 heading "Case progress"
+    And I should see a "m" sized level 3 heading with text "Case progress"
     And hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e7" should have link "Edit"
     And hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e5" should have link "Edit"
 

--- a/integration-tests/cypress/e2e/case-summary.feature
+++ b/integration-tests/cypress/e2e/case-summary.feature
@@ -17,7 +17,7 @@ Feature: Case summary
     And I should see the caption with the court name "Sheffield Magistrates' Court"
     When I click the "Kara Ayers" link
     Then I should be on the "Case summary" page
-    And I should see the level 2 heading "Kara Ayers"
+    And I should see a level 1 heading with text "Kara Ayers"
     And I should see back link "Back to cases" with href "/B14LO/cases?page=1"
     And I should see the caption text "Source: Libra"
     And I should see the caption text "Case number: 8678951874"
@@ -43,8 +43,10 @@ Feature: Case summary
     And I should see the caption text "URN: 01WW0298121"
     And I should see sub navigation with the following links
       | Case summary | Probation record | Risk register |
-    And I should see the following level 2 headings
-      | Mann Carroll | Defendant details | Case documents | Appearance | Offences |
+    And I should see a level 1 heading with text "Mann Carroll"
+    And I should see a "l" sized level 2 heading with text "Case summary"
+    And I should see the following "m" sized level 3 headings
+     | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
 
     And I should see the body text "Court 2-3, afternoon session, $LONG_TODAY."
     Then I should see the following list of charges in an accordion component
@@ -71,8 +73,11 @@ Feature: Case summary
     Then I should be on the "Case summary" page
     And I should see back link "Back to cases" with href "/B14LO/cases/$TODAY"
     And I should see the body text "Probation status: Possible NDelius record"
-    And I should see the following level 2 headings
-      | Guadalupe Hess | possible NDelius records found | Defendant details | Case documents | Appearance | Offences |
+    And I should see a level 1 heading with text "Guadalupe Hess"
+    And I should see a "l" sized level 2 heading with text "Case summary"
+    And I should see a "m" sized level 2 heading with text "possible NDelius records found"
+    And I should see the following "m" sized level 3 headings
+      | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
 
     And I should see the body text "Court 7, morning session, $LONG_TODAY."
     Then I should see the following list of charges in an accordion component
@@ -97,8 +102,10 @@ Feature: Case summary
     And I should see back link "Back to cases" with href "/B14LO/cases/$TODAY"
     Then I should see the body text "Probation status: No record"
     And I should not see the case level navigation
-    And I should see the following level 2 headings
-      | Kara Ayers | Defendant details | Case documents | Appearance | Offences |
+    And I should see a level 1 heading with text "Kara Ayers"
+    And I should see a "l" sized level 2 heading with text "Case summary"
+    And I should see the following "m" sized level 3 headings
+      | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
 
     And I should see the body text "Court Crown Court 3-1, morning session, $LONG_TODAY."
     Then I should see the following list of charges in an accordion component
@@ -132,8 +139,10 @@ Feature: Case summary
     Then I should see the body text "PNC: A/8404713BA"
     Then I should see the body text "Probation status: Previously known"
     And I should see a straight line divide
-    And I should see the following level 2 headings
-      | Webb Mitchell | Defendant details | Case documents | Appearance | Offences |
+    And I should see a level 1 heading with text "Webb Mitchell"
+    And I should see a "l" sized level 2 heading with text "Case summary"
+    And I should see the following "m" sized level 3 headings
+      | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
 
     And I should see the body text "Court 8, morning session, $LONG_TODAY."
     Then I should see the following list of charges in an accordion component
@@ -169,8 +178,10 @@ Feature: Case summary
     And I should see the caption text "URN: 01WW0298121"
     And I should see sub navigation with the following links
       | Case summary | Probation record | Risk register |
-    And I should see the following level 2 headings
-      | Mann Carroll | Defendant details | Case documents | Appearance | Offences |
+    And I should see a level 1 heading with text "Mann Carroll"
+    And I should see a "l" sized level 2 heading with text "Case summary"
+    And I should see the following "m" sized level 3 headings
+      | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
 
     And I should see the body text "Court 2-3, afternoon session, $LONG_TODAY."
     Then I should see the following list of charges in an accordion component
@@ -202,8 +213,10 @@ Feature: Case summary
     And I should see the body text "PNC: A/1234560BA"
     And I should see the body text "Probation status: Current (PSR)"
     And I should see a straight line divide
-    And I should see the following level 2 headings
-      | Lenore Marquez | Defendant details | Case documents | Appearance | Offences |
+    And I should see a level 1 heading with text "Lenore Marquez"
+    And I should see a "l" sized level 2 heading with text "Case summary"
+    And I should see the following "m" sized level 3 headings
+      | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
 
     And I should see the body text "Court 6, morning session, $LONG_TODAY."
     Then I should see the following list of charges in an accordion component
@@ -239,8 +252,10 @@ Feature: Case summary
     And I should see the body text "PNC: D/9874483AB"
     And I should see the body text "Probation status: Current (Breach)"
     And I should see a straight line divide
-    And I should see the following level 2 headings
-      | Olsen Alexander | Defendant details | Case documents | Appearance | Offences |
+    And I should see a level 1 heading with text "Olsen Alexander"
+    And I should see a "l" sized level 2 heading with text "Case summary"
+    And I should see the following "m" sized level 3 headings
+      | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
 
     And I should see the body text "Court 9, morning session, $LONG_TODAY."
     And I should see the body text "Theft from a shop" in bold
@@ -272,9 +287,9 @@ Feature: Case summary
     Then I should be on the "Case summary" page
     And I should see back link "Back to cases" with href "/B14LO/cases?page=1"
     When I click the sub navigation with "Probation record" text
-    Then I should see the level 2 heading "Pre-sentence report requested (2)"
-    Then I should see the level 2 heading "Current orders (1)"
-    Then I should see the level 2 heading "Previous orders (4)"
+    Then I should see a level 2 heading with text "Pre-sentence report requested (2)"
+    Then I should see a level 2 heading with text "Current orders (1)"
+    Then I should see a level 2 heading with text "Previous orders (4)"
     And I should see the body text "Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801"
     And I should see the hint text "Offence committed on 10 November 2017"
     And I should see the body text "Report requested on 5 July 2021"
@@ -285,8 +300,10 @@ Feature: Case summary
       | Status      | Complete (8 July 2021)     |
     And I should see the body text "Noise offences - 82200"
     And I should see the hint text "Offence committed on 6 January 2021"
-    And I should see the following level 2 headings
-      | Webb Mitchell | Pre-sentence report requested | Current orders | Previous orders | Last OASys assessment |
+    And I should see a level 1 heading with text "Webb Mitchell"
+    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see the following "m" sized level 2 headings
+      | Pre-sentence report requested | Current orders | Previous orders | Last OASys assessment |
     And There should be no a11y violations
 
   Scenario: View the probation record section of the case summary for a current offender
@@ -299,20 +316,22 @@ Feature: Case summary
     When I clear the filters
     When I click the "Lenore Marquez" link
     And I click the sub navigation with "Probation record" text
-    Then I should see the level 2 heading "Current orders (3)"
+    Then I should see a level 2 heading with text "Current orders (3)"
     And I should see link "ORA Community Order (18 Months)" with href "record/1403337513"
     And I should see the text "Curfew Arrangement" within element with class "qa-current-licence-conditions-1"
     And I should see the text "Curfew Arrangement" within element with class "qa-current-pss-requirements-2"
     And I should see the body text "Stealing mail bags or postal packets or unlawfully taking away or opening mail bag - 04200"
     And I should see the hint text "Started on 20 May 2019"
 
-    And I should see the level 2 heading "Previous orders (11)"
+    And I should see a level 2 heading with text "Previous orders (11)"
     And I should see link "CJA - Std Determinate Custody" with href "record/636401162"
     And I should see the text "Burglary (dwelling) with intent to commit, or the commission of an offence triable only on indictment - 02801" within element with class "qa-previous-order-1-offence"
     And I should see the text "Ended on 23 Jan 2018" within element with class "qa-previous-order-1-end-date"
+    And I should see a level 1 heading with text "Lenore Marquez"
+    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see the following "m" sized level 2 headings
+      | Pre-sentence report requested | Current orders | Previous orders | Offender manager | Last pre-sentence report | Last OASys assessment |
 
-    And I should see the following level 2 headings
-      | Lenore Marquez | Pre-sentence report requested | Current orders | Previous orders | Offender manager | Last pre-sentence report | Last OASys assessment |
     And I should see the body text "Angel Extravaganza"
     And I should see the hint text "Allocated on 12 Aug 2017"
     And I should see the body text "Email: d@none.com"
@@ -366,7 +385,10 @@ Feature: Case summary
     When I click the "Latoya Kirkland" link
     Then I should be on the "Case summary" page
     And I should see back link "Back to cases" with href "/B14LO/cases?page=1"
-    And I should see the level 2 heading "Latoya Kirkland"
+    And I should see a level 1 heading with text "Latoya Kirkland"
+    And I should see a "l" sized level 2 heading with text "Case summary"
+    And I should see the following "m" sized level 3 headings
+      | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
     When I click the sub navigation with "Probation record" text
     Then I should see the heading "You are restricted from viewing this record"
 
@@ -380,7 +402,10 @@ Feature: Case summary
 
     When I navigate to the "/B14LO/hearing/4e10a261-2d0f-4b07-a684-e2b03ee54a4f/defendant/cf6ce65e-48f9-4b62-9d39-67fbfe68e9fc/record" base route
     Then I should be on the "Probation record" page
-    And I should see the level 2 heading "Lenore Marquez"
+    And I should see a level 1 heading with text "Lenore Marquez"
+    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see the following "m" sized level 2 headings
+      | Pre-sentence report requested | Current orders | Previous orders | Last OASys assessment |
 
     When I click the "ORA Community Order (18 Months)" link
     Then I should be on the "ORA Community Order (18 Months)" page
@@ -509,7 +534,10 @@ Feature: Case summary
 
     When I navigate to the "/B14LO/hearing/8d187ea4-d24d-4806-a5c7-1626919c44bb/defendant/9f60bdb8-0978-404c-bd89-addc3f5388a7/record" base route
     Then I should be on the "Probation record" page
-    And I should see the level 2 heading "Olsen Alexander"
+    And I should see a level 1 heading with text "Olsen Alexander"
+    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see the following "m" sized level 2 headings
+      | Current orders | Previous orders | Offender manager | Last pre-sentence report | Last OASys assessment |
 
     And I should see medium heading with text "Last pre-sentence report"
     And I should see the body text "Pre-Sentence Report - Fast"
@@ -609,7 +637,10 @@ Feature: Case summary
 
     When I navigate to the "/B14LO/hearing/4e10a261-2d0f-4b07-a684-e2b03ee54a4f/defendant/cf6ce65e-48f9-4b62-9d39-67fbfe68e9fc/record" base route
     Then I should be on the "Probation record" page
-    And I should see the level 2 heading "Lenore Marquez"
+    And I should see a level 1 heading with text "Lenore Marquez"
+    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see the following "m" sized level 2 headings
+      | Pre-sentence report requested | Current orders | Previous orders | Last OASys assessment |
 
     When I click the "CJA - Std Determinate Custody" link
     Then I should be on the "CJA - Std Determinate Custody (18 Months)" page
@@ -632,7 +663,7 @@ Feature: Case summary
   Scenario: View the case details of a defendant to see a list of current charges and the associated summary/description
     Given I am an authenticated user
     When I navigate to the "/B14LO/hearing/4e10a261-2d0f-4b07-a684-e2b03ee54a4f/defendant/cf6ce65e-48f9-4b62-9d39-67fbfe68e9fc/summary" base route
-    Then I should see the level 2 heading "Offences"
+    And I should see a level 1 heading with text "Lenore Marquez"
     And If the total number of charges is greater than one
     Then I should see the following list of charges in an accordion component
       | Attempt theft from the person of another |
@@ -650,7 +681,7 @@ Feature: Case summary
 
     When I navigate to the "/B14LO/hearing/4e10a261-2d0f-4b07-a684-e2b03ee54a4f/defendant/cf6ce65e-48f9-4b62-9d39-67fbfe68e9fc/record" base route
     Then I should be on the "Probation record" page
-    And I should see the level 2 heading "Lenore Marquez"
+    And I should see a level 1 heading with text "Lenore Marquez"
 
     When I click the "ORA Community Order (18 Months)" link
     Then I should be on the "ORA Community Order (18 Months)" page
@@ -664,7 +695,7 @@ Feature: Case summary
 
     When I navigate to the "/B14LO/hearing/4e10a261-2d0f-4b07-a684-e2b03ee54a4f/defendant/cf6ce65e-48f9-4b62-9d39-67fbfe68e9fc/record" base route
     Then I should be on the "Probation record" page
-    And I should see the level 2 heading "Lenore Marquez"
+    And I should see a level 1 heading with text "Lenore Marquez"
 
     When I click the "CJA - Std Determinate Custody" link
     Then I should be on the "CJA - Std Determinate Custody (18 Months)" page

--- a/integration-tests/cypress/support/step_definitions/common.js
+++ b/integration-tests/cypress/support/step_definitions/common.js
@@ -137,34 +137,6 @@ Then('I should be on the {string} page', $title => {
   cy.get('title').contains(`${$title} - `)
 })
 
-Then('I should see medium heading with text {string}', $string => {
-  cy.get('.govuk-heading-m').contains($string).should('exist')
-})
-
-Then('I should see the heading {string}', $title => {
-  cy.get('h1').contains($title)
-})
-
-Then('I should see the level 2 heading {string}', $title => {
-  cy.get('h2').contains($title)
-})
-
-Then('I should see the level 3 heading {string}', $title => {
-  cy.get('h3').contains($title)
-})
-
-Then('I should see the following level 2 headings', $data => {
-  $data.raw()[0].forEach((text, index) => {
-    cy.get('h2').eq(index).contains(text)
-  })
-})
-
-Then('I should see the following level 3 headings', $data => {
-  $data.raw()[0].forEach((text, index) => {
-    cy.get('h3').eq(index).contains(text)
-  })
-})
-
 Then('I should see the following table headings', $data => {
   $data.raw()[0].forEach((text, index) => {
     if (text) {
@@ -172,7 +144,7 @@ Then('I should see the following table headings', $data => {
     }
   })
 })
-
+  
 Then('I should see the following table {int} headings', ($index, $data) => {
   cy.get('.govuk-table').eq($index - 1).within(() => {
     $data.raw()[0].forEach((text, index) => {
@@ -224,10 +196,6 @@ Then('I should see the following table {int} rows', ($int, $data) => {
 
 Then('I should logout', () => {
   cy.get('.moj-header__navigation-link').click()
-})
-
-Then('I should not see the heading level {int} with text {string}', ($level, $text) => {
-  cy.get(`h${$level}`).contains($text).should('not.exist')
 })
 
 Then('I should see the caption {string}', $caption => {

--- a/integration-tests/cypress/support/step_definitions/headings.js
+++ b/integration-tests/cypress/support/step_definitions/headings.js
@@ -1,0 +1,45 @@
+const { Then } = require('@badeball/cypress-cucumber-preprocessor')
+
+Then('I should see medium heading with text {string}', $string => {
+    cy.get('.govuk-heading-m').contains($string).should('exist')
+  })
+  
+  Then('I should see the heading {string}', $title => {
+    cy.get('h1').contains($title)
+  })
+  
+  Then('I should see the level 2 heading {string}', $title => {
+    cy.get('h2').contains($title)
+  })
+  
+  Then('I should see the level 3 heading {string}', $title => {
+    cy.get('h3').contains($title)
+  })
+
+  Then('I should not see the heading level {int} with text {string}', ($level, $text) => {
+    cy.get(`h${$level}`).contains($text).should('not.exist')
+  })
+
+  Then('I should see a {string} sized level {int} heading with the text {string}', ($size, $level, $text) => {
+    cy.get(`h${$level} .govuk-heading-${$size}`).contains($text).should('exist')
+  })
+
+//////////
+
+Then('I should see a level {int} heading with text {string}', ($level, $text) => {
+    cy.get(`h${$level}`).contains($text).should('exist')
+})
+Then('I should see a {string} sized level {int} heading with text {string}', ($size, $level, $text) => {
+    cy.get(`h${$level}.govuk-heading-${$size}`).contains($text).should('exist')
+})
+Then('I should see the following level {int} headings', ($level, $data) => {
+    cy.debug($level, $data)
+    $data.raw()[0].forEach((text) => {
+        cy.get(`h${$level}`).contains(text)
+      })
+})
+Then('I should see the following {string} sized level {int} headings', ($size, $level, $data) => {
+    $data.raw()[0].forEach((text) => {
+        cy.get(`h${$level}.govuk-heading-${$size}`).contains(text)
+      })
+})

--- a/integration-tests/cypress/support/step_definitions/headings.js
+++ b/integration-tests/cypress/support/step_definitions/headings.js
@@ -1,43 +1,44 @@
 const { Then } = require('@badeball/cypress-cucumber-preprocessor')
 
 Then('I should see medium heading with text {string}', $string => {
-    cy.get('.govuk-heading-m').contains($string).should('exist')
-  })
-  
-  Then('I should see the heading {string}', $title => {
-    cy.get('h1').contains($title)
-  })
-  
-  Then('I should see the level 2 heading {string}', $title => {
-    cy.get('h2').contains($title)
-  })
-  
-  Then('I should see the level 3 heading {string}', $title => {
-    cy.get('h3').contains($title)
-  })
+  cy.get('.govuk-heading-m').contains($string).should('exist')
+})
 
-  Then('I should not see the heading level {int} with text {string}', ($level, $text) => {
-    cy.get(`h${$level}`).contains($text).should('not.exist')
-  })
+Then('I should see the heading {string}', $title => {
+  cy.get('h1').contains($title)
+})
 
-  Then('I should see a {string} sized level {int} heading with the text {string}', ($size, $level, $text) => {
-    cy.get(`h${$level} .govuk-heading-${$size}`).contains($text).should('exist')
-  })
+Then('I should see the level 2 heading {string}', $title => {
+  cy.get('h2').contains($title)
+})
 
-//////////
+Then('I should see the level 3 heading {string}', $title => {
+  cy.get('h3').contains($title)
+})
+
+Then('I should not see the heading level {int} with text {string}', ($level, $text) => {
+  cy.get(`h${$level}`).contains($text).should('not.exist')
+})
+
+Then('I should see a {string} sized level {int} heading with the text {string}', ($size, $level, $text) => {
+  cy.get(`h${$level} .govuk-heading-${$size}`).contains($text).should('exist')
+})
 
 Then('I should see a level {int} heading with text {string}', ($level, $text) => {
     cy.get(`h${$level}`).contains($text).should('exist')
 })
+
 Then('I should see a {string} sized level {int} heading with text {string}', ($size, $level, $text) => {
     cy.get(`h${$level}.govuk-heading-${$size}`).contains($text).should('exist')
 })
+
 Then('I should see the following level {int} headings', ($level, $data) => {
     cy.debug($level, $data)
     $data.raw()[0].forEach((text) => {
         cy.get(`h${$level}`).contains(text)
       })
 })
+
 Then('I should see the following {string} sized level {int} headings', ($size, $level, $data) => {
     $data.raw()[0].forEach((text) => {
         cy.get(`h${$level}.govuk-heading-${$size}`).contains(text)

--- a/server/views/case-summary.njk
+++ b/server/views/case-summary.njk
@@ -101,16 +101,16 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-l">Case summary</h1>
+            <h2 class="govuk-heading-l">Case summary</h2>
         </div>
     </div>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
-            <h2 class="govuk-heading-m">
+            <h3 class="govuk-heading-m">
                 Defendant details
-            </h2>
+            </h3>
 
             <dl class="govuk-summary-list govuk-summary-list--no-border">
                 <div class="govuk-summary-list__row">
@@ -179,15 +179,13 @@
 
             {% if features.hearingOutcomesEnabled %}
                 <section id="section-files" class="govuk-!-margin-bottom-4">
-                    <h2 class="govuk-heading-m govuk-!-margin-top-9">
-                        Case documents
-                    </h2>
+                    <h3 class="govuk-heading-m govuk-!-margin-top-9">Case documents</h3>
                     <p class="govuk-body">Upload documents to attach them to this case.</p>
                     {{ pacFileUploader('summary/files', data.files, config.files) }}
                 </section>
             {% endif %}
 
-            <h2 class="govuk-heading-m">Appearance</h2>
+            <h3 class="govuk-heading-m">Appearance</h3>
             <p class="govuk-body">Court {{ courtRoom | courtRoomDisplay }}, {{ data.session | lower }} session,
                 {{ moment(data.sessionStartTime).format('dddd D MMMM') }}.</p>
 
@@ -197,7 +195,7 @@
                 </p>
             {% endif %}
 
-            <h2 class="govuk-heading-m govuk-!-margin-top-9">Offences</h2>
+            <h3 class="govuk-heading-m govuk-!-margin-top-9">Offences</h3>
 
             {% set offences = [] %}
             {% for offence in data.offences %}

--- a/server/views/components/key-details-bar/template.njk
+++ b/server/views/components/key-details-bar/template.njk
@@ -7,9 +7,9 @@
 
             <div class="pac-key-details-bar-flex">
                 <div class="pac-key-details-bar-flex__child">
-                    <h2 class="pac-key-details-bar__name govuk-!-margin-right-4">{% if params.accTitle %}<span
-                                class="govuk-visually-hidden">{{ params.accTitle }}</span>{% endif %}{{ params.title }}
-                    </h2>
+                    <h1 class="pac-key-details-bar__name govuk-!-margin-right-4">{% if params.accTitle %}
+                        <span class="govuk-visually-hidden">{{ params.accTitle }}</span>{% endif %}{{ params.title }}
+                    </h1>
                 </div>
                 {% if params.crn | length %}
                     <div class="pac-key-details-bar-flex__child">

--- a/server/views/court-case-comments.njk
+++ b/server/views/court-case-comments.njk
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds" id="caseComments">
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-        <h2 class="govuk-heading-m">Comments</h2>
+        <h3 class="govuk-heading-m">Comments</h3>
         {% if session.deleteCommentSuccess === data.caseId %}
             {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
             {% set html %}

--- a/server/views/court-case-progress.njk
+++ b/server/views/court-case-progress.njk
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row" id="caseProgressComponent">
     <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m" id="caseHearingsHeading">Case progress</h2>
+        <h3 class="govuk-heading-m" id="caseHearingsHeading">Case progress</h3>
         {% if features.hearingOutcomesEnabled %}
             {% include "court-case-progress-hearing-outcome-modal.njk" %}
             {% include "court-case-progress-hearing-outcome-edit-modal.njk" %}


### PR DESCRIPTION
Change the heading hierarchy on case-summary so that:
- The defendant name is a h1
- The title "Case Summary" is a large h2
- All other subsequent titles are medium h3s.

Moved the heading steps into their own file to focus what is going on outside of the monolithic common steps definition and focus on new steps that can test either the level or the level and the size either singularly or in a series.
Tempted to follow this up in a refactor to move everything to the same as we have multiple preexisting steps steps that test for the same thing but that will be a separate PR just to avoid losing sight of these changes.