### PR TITLE
PIC-3154: Risk register table column - non fixed width

### DIFF
--- a/server/views/case-summary-risk.njk
+++ b/server/views/case-summary-risk.njk
@@ -50,7 +50,7 @@
                                 <th scope="col" class="govuk-table__header">Type</th>
                                 <th scope="col" class="govuk-table__header">Registered</th>
                                 <th scope="col" class="govuk-table__header">Next review</th>
-                                <th scope="col" class="govuk-table__header govuk-!-width-one-half">Notes</th>
+                                <th scope="col" class="govuk-table__header">Notes</th>
                             </tr>
                             </thead>
                             {%- for risk in activeRisks %}
@@ -77,7 +77,7 @@
                                 <th scope="col" class="govuk-table__header">Type</th>
                                 <th scope="col" class="govuk-table__header">Registered</th>
                                 <th scope="col" class="govuk-table__header">End date</th>
-                                <th scope="col" class="govuk-table__header govuk-!-width-one-half">Notes</th>
+                                <th scope="col" class="govuk-table__header">Notes</th>
                             </tr>
                             </thead>
                             {%- for risk in inactiveRisks %}


### PR DESCRIPTION
Remove half width class from notes column on the risk register tables and allow them to auto set width, makes the most difference during zoom in/when the window is smaller (see the bottom most screencap).

Table before:
![image](https://github.com/user-attachments/assets/05a684fb-d9c6-4ac2-b161-69a74bcad5a6)
![image](https://github.com/user-attachments/assets/4f136940-5956-492e-beaa-412970efa30e)

Table after:
![image](https://github.com/user-attachments/assets/2a59efad-8ffe-4090-b3f0-183d19775d4f)
![image](https://github.com/user-attachments/assets/35e660d1-add0-4819-a646-1db2c96c4fa1)
