### PR TITLE
PIC-3149: Case Summary - Offences heading 

### DIFF
--- a/integration-tests/cypress/e2e/case-summary.feature
+++ b/integration-tests/cypress/e2e/case-summary.feature
@@ -258,7 +258,7 @@ Feature: Case summary
       | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
 
     And I should see the body text "Court 9, morning session, $LONG_TODAY."
-    And I should see the body text "Theft from a shop" in bold
+    And I should see the following singular charge with title "Theft from a shop"
     And I should see the body text "On 01/01/2015 at Tetratrex, Leeds, stole ROBOTS to the value of £987.00, belonging to Young Bryant."
     And I should see the caption text "Contrary to section 1(1) and 7 of the Theft Act 1968."
 

--- a/integration-tests/cypress/e2e/case-summary/case-summary.steps.js
+++ b/integration-tests/cypress/e2e/case-summary/case-summary.steps.js
@@ -61,10 +61,14 @@ Then('If the total number of charges is greater than one', () => {
   cy.get('.govuk-accordion').should('exist')
 })
 
+Then('I should see the following singular charge with title {string}', (title) => {
+  cy.get('h4.govuk-body').should('exist').contains(title).should('have.attr', 'class').and('include', 'govuk-!-font-weight-bold')
+})
+
 Then('I should see the following list of charges in an accordion component', $data => {
   cy.get('.govuk-accordion').within(() => {
     $data.raw().flat().forEach((text, index) => {
-      cy.get('.govuk-accordion__section-button').eq(index).contains(text)
+      cy.get('h4 .govuk-accordion__section-button').eq(index).contains(text)
     })
   })
 })

--- a/server/views/case-summary.njk
+++ b/server/views/case-summary.njk
@@ -201,26 +201,24 @@
             {% for offence in data.offences %}
                 {{ offences.push(data.offences) | length }}
             {% endfor %}
-            {% if offences | length < 2 %}
+            {% if offences | length == 1 %}
                 {% for offence in data.offences %}
-                    <p class="govuk-body govuk-!-font-weight-bold">{{ offence.offenceTitle }}</p>
+                    <h4 class="govuk-body govuk-!-font-weight-bold">{{ offence.offenceTitle }}</h4>
                     <p class="govuk-body govuk-!-margin-bottom-0">{{ offence.offenceSummary }}</p>
                     <p class="govuk-caption-m govuk-!-margin-top-3">{{ offence.act }}</p>
                 {% endfor %}
-                {% elif offences | length > 1 %}
+            {% elif offences | length > 1 %}
                 <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-{{ params.caseId }}">
                     {% for offence in data.offences %}
                         <div class="govuk-accordion__section">
                             <div class="govuk-accordion__section-header">
-                                <h2 class="govuk-accordion__section-heading">
-                                <span class="govuk-accordion__section-button"
-                                      id="accordion-{{ params.caseId }}-heading-{{ loop.index }}">
-                                    <span class="pac-accordion-section-heading">{{ offence.offenceTitle }}</span>
-                                </span>
-                                </h2>
+                                <h4 class="govuk-accordion__section-heading">
+                                    <span class="govuk-accordion__section-button" id="accordion-{{ params.caseId }}-heading-{{ loop.index }}">
+                                        <span class="pac-accordion-section-heading">{{ offence.offenceTitle }}</span>
+                                    </span>
+                                </h4>
                             </div>
-                            <div id="accordion-{{ params.caseId }}-content-{{ loop.index }}"
-                                 class="govuk-accordion__section-content">
+                            <div id="accordion-{{ params.caseId }}-content-{{ loop.index }}" class="govuk-accordion__section-content">
                                 <p class="govuk-body govuk-!-margin-bottom-0">{{ offence.offenceSummary }}</p>
                                 <p class="govuk-caption-m govuk-!-margin-top-3">{{ offence.act }}</p>
                             </div>


### PR DESCRIPTION
[PIC-3149](https://dsdmoj.atlassian.net/browse/PIC-3149)

Update case summary offence heading to be h4 in line with the rest of the page.

Singular offence:
![image](https://github.com/user-attachments/assets/e826469f-76f6-499c-ab6f-f48789f71907)

Multiple offences:
![image](https://github.com/user-attachments/assets/18ec2c4c-fdfa-4121-b853-037a6b286d6c)


[PIC-3149]: https://dsdmoj.atlassian.net/browse/PIC-3149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ