### PR TITLE
PIC 3143: Modal component, request UCD update

### DIFF
--- a/public/src/stylesheets/app/_bootstrap-modal.scss
+++ b/public/src/stylesheets/app/_bootstrap-modal.scss
@@ -173,7 +173,8 @@
   flex-wrap: wrap;
   align-items: center; // vertically center
   justify-content: flex-start; // put footer elements on the left
-  padding: calc(var(--#{$prefix}modal-padding) - var(--#{$prefix}modal-footer-gap) * .5);
+  padding-top: calc(var(--#{$prefix}modal-padding) - var(--#{$prefix}modal-footer-gap) * .5);
+  padding-bottom: calc(var(--#{$prefix}modal-padding) - var(--#{$prefix}modal-footer-gap) * .5);
   background-color: var(--#{$prefix}modal-footer-bg);
   border-top: var(--#{$prefix}modal-footer-border-width) solid var(--#{$prefix}modal-footer-border-color);
   @include border-bottom-radius(var(--#{$prefix}modal-inner-border-radius));

--- a/server/views/components/modal/macro.njk
+++ b/server/views/components/modal/macro.njk
@@ -3,7 +3,7 @@
 
   params: {
     * id: id for the modal,
-    * size: optional size class for the modal
+      size: optional size class for the modal
     * classList: an array of classes to append to the modal,
     * heading: text that will appears as the modal heading,
       bodyContent: html that will appear in the body of the modal


### PR DESCRIPTION
[[PIC-3143](https://dsdmoj.atlassian.net/browse/PIC-3143)]

A small change request by UCD, removing the left and right padding from the .modal-footer area so that the button align with the left hand content as based on the [Service Timeout](https://design.tax.service.gov.uk/hmrc-design-patterns/service-timeout/), which we are using as the design basis for our modals.

Left, before: footer has all around padding but notable on the left and right.
Right, after: footer still has padding on top and bottom but no longer on the left and right.
![image](https://github.com/user-attachments/assets/19df64b9-3384-4497-8e65-67468e9ef86d)

[PIC-3143]: https://dsdmoj.atlassian.net/browse/PIC-3143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ