### PR TITLE
PIC-3150: Case details skip link

### DIFF
--- a/server/views/partials/case-details.njk
+++ b/server/views/partials/case-details.njk
@@ -77,15 +77,21 @@
 
 {% endblock %}
 
+{% block subNav %}
+    {% if (subNavItems | length > 0) %}
+        {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+        {{ mojSubNavigation({
+            classes: 'govuk-width-container',
+            label: 'Sub navigation',
+            items: subNavItems
+        })}}
+    {% endif %}
+{% endblock %}
+
+
 {% block content %}
 
     {% block message %}{% endblock %}
-
-    {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
-    {{ mojSubNavigation({
-        label: 'Sub navigation',
-        items: subNavItems
-    }) if subNavItems | length and not hideSubnav }}
 
     {% block caseContent %}{% endblock %}
 

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -181,6 +181,8 @@
     {% block backlink %}{% endblock %}
 </nav>
 
+{% block subNav %}{% endblock %}
+
 {% if globalErrors %}
 <div class="govuk-width-container" style="margin-top: 7px">
     {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}


### PR DESCRIPTION
[PIC-3150](https://dsdmoj.atlassian.net/browse/PIC-3150): Move the case details sub-navigation out of the main-content so that it is skipped by the skip link

Previously, the block for sub navigation used in Case Details was a part of the main-content block. Given that main-content is the target of the skip link, this means any AT users relying on the A11Y DOM had to move over any-and all entries when present to reach the page specific content.
By moving it outside of the area, it will be skipped when the skip link is used whilst it remain a nav element so that shortcuts can easily move to it when navigation is desired.

New layout compared to old.

An example where no sub navigation rendered, no discernable difference:
![image](https://github.com/user-attachments/assets/716ead7b-f847-4597-9081-550230830a7d)

An example of where sub navigation is rendered, critically where it is not within the main-content block. This has the effect of the space appearing beneath the sub nav but this is fine as the space is meant to delineate between the page's main content and the surround, the latter of which the sub navigation is now to be a part with:
![image](https://github.com/user-attachments/assets/87d0cafb-c170-4b3b-bfa4-477f39f373ed)



[PIC-3150]: https://dsdmoj.atlassian.net/browse/PIC-3150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ