### PR TITLE
PIC-3232: Improve accessibility for case search errors

### DIFF
--- a/integration-tests/cypress/support/step_definitions/common.js
+++ b/integration-tests/cypress/support/step_definitions/common.js
@@ -440,17 +440,20 @@ Then('I enter invalid search term into search input and click search then I shou
 })
 
 When('I enter search term {string} into search input and click search then I should see error {string}', ($searchTerm, $expectedError) => {
-  cy.get('#search-term').clear()
-  cy.get('#search-term').type($searchTerm)
+  const inputId = '#search-term'
+  cy.get(inputId).clear()
+  cy.get(inputId).type($searchTerm)
   cy.get('.govuk-button').contains('Search').click()
 
   if ($expectedError === 'NO_ERROR') {
     cy.get('.govuk-error-summary').should('not.exist')
     cy.get('.govuk-form-group--error .govuk-error-message').should('not.exist')
   } else {
+    cy.get('title').should('contain.text', 'Error:')
     cy.get('.govuk-error-summary').within(() => {
       cy.get('h2').should('contain.text', 'There is a problem')
       cy.get('a').should('have.text', $expectedError)
+      cy.get('a').should('have.attr', 'href', `${inputId}`)
     })
     cy.get('.govuk-form-group--error .govuk-error-message').should('contain.text', `Error:${$expectedError}`)
   }

--- a/integration-tests/cypress/support/step_definitions/common.js
+++ b/integration-tests/cypress/support/step_definitions/common.js
@@ -453,7 +453,7 @@ When('I enter search term {string} into search input and click search then I sho
     cy.get('.govuk-error-summary').within(() => {
       cy.get('h2').should('contain.text', 'There is a problem')
       cy.get('a').should('have.text', $expectedError)
-      cy.get('a').should('have.attr', 'href', `${inputId}`)
+      cy.get('a').should('have.attr', 'href', inputId)
     })
     cy.get('.govuk-form-group--error .govuk-error-message').should('contain.text', `Error:${$expectedError}`)
   }

--- a/server/views/case-search.njk
+++ b/server/views/case-search.njk
@@ -1,6 +1,6 @@
 {% extends "partials/layout.njk" %}
 
-{% set title = "Search result" %}
+{% set title = "Error: Search result" if searchError else "Search result" %}
 
 {% set tableData = {
     head: [

--- a/server/views/components/search/template.njk
+++ b/server/views/components/search/template.njk
@@ -1,3 +1,5 @@
+{% set inputId = "search-term" %}
+
 {% if params.searchError %}
     <div class="govuk-error-summary" data-module="govuk-error-summary">
         <div role="alert">
@@ -7,7 +9,7 @@
             <div class="govuk-error-summary__body">
                 <ul class="govuk-list govuk-error-summary__list">
                     <li>
-                        <a href="#error-validate-characters">{{ params.searchError }}</a>
+                        <a href="#{{inputId}}">{{ params.searchError }}</a>
                     </li>
                 </ul>
             </div>
@@ -25,8 +27,8 @@
         {% endif %}
         <form name="pac-search-form" id="pac-search-form" method="get" action="/case-search">
             <div class="search-group">
-                <label class="govuk-label govuk-!-margin-bottom-3" for="search-term">Enter the CRN or full name of the person you are searching for.</label>
-                <input class="govuk-input govuk-!-width-one-third" id="search-term" name="term" type="text" maxlength="650" value="{{ params.term }}">
+                <label class="govuk-label govuk-!-margin-bottom-3" for="{{inputId}}">Enter the CRN or full name of the person you are searching for.</label>
+                <input class="govuk-input govuk-!-width-one-third" id="{{inputId}}" name="term" type="text" maxlength="650" value="{{ params.term }}">
                 <button class="govuk-button action-button govuk-!-margin-bottom-1 govuk-!-margin-left-3" data-module="govuk-button" type="submit">Search</button>
             </div>
         </form>


### PR DESCRIPTION
On case search error screen, adds "error" to title tag so screen readers read it out as soon as possible. Also ensures that error summary links to error field, complying with GDS guidelines.

Updates Cypress tests to assert the above.