### PR TITLE
Pic 3148/show confirmation when a note is added

### DIFF
--- a/integration-tests/cypress/e2e/case-progress.feature
+++ b/integration-tests/cypress/e2e/case-progress.feature
@@ -18,9 +18,12 @@ Feature: Case progress
     And I should see "Expand to add a hearing note" link on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
 
     When I click Expand to add a hearing note on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
-    Then I should see a text area wih label Add information specific to this hearing on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
+    Then I should see a text area with label Add information specific to this hearing on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
     And I should see a Save button on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
     And I should see a Cancel saving note link on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
+
+    When I click the Save button on hearing with id "2aa6f5e0-f842-4939-bc6a-01346abc09e7"
+    Then I should see govuk notification banner with header "Success" and message "You successfully added a note"
 
   Scenario: View hearing note on the case summary page
     Given I am an authenticated user
@@ -47,6 +50,8 @@ Feature: Case progress
       | 8th hearing         | Wednesday 14 August 2019, Court 2, morning session, Leicester     |                 |
       | 7th hearing         | Sunday 14 July 2019, Court 1, morning session, Leicester          |                 |
       | 5th hearing         | Tuesday 14 May 2019, Court 2, morning session, North Shields      |                 |
+
+    And I should see "Send outcome to admin" button on hearing with id "2aa6f5e0-f842-4939-bc6a-01346abc09e3" 
 
     And I should see a bottom border on all notes within a hearing
     And I should see a button with the label "Show all previous hearings"
@@ -111,6 +116,28 @@ Feature: Case progress
     Then I should be on the "Case summary" page
     And I should not see govuk notification banner
 
+  Scenario: Edit hearing note on the case summary page
+    Given I am an authenticated user
+    And I click the "Accept analytics cookies" button
+    Then I should not see the cookie banner
+
+    When I navigate to the "/B14LO/hearing/5b9c8c1d-e552-494e-bc90-d475740c64d8/defendant/8597a10b-d330-43e5-80c3-27ce3b46979f/summary" base route
+    Then I should be on the "Case summary" page
+    And I should see back link "Back to cases" with href "/B14LO/cases/$TODAY"
+    And I should see the caption text "URN: 01WW0298121"
+
+    And I should see the following summary list
+      | Name          | Kara Ayers                                                            |
+      | Gender        | Female                                                                |
+      | Date of birth | 31 October 1980 (41 years old)                                        |
+      | Address       | 22 Waldorf Court Cardiff AD21 5DR                                     |
+
+    And I should see a "m" sized level 3 heading with text "Case progress"
+    And I should see 6 previous hearings headers
+
+    When I click edit hearing note with id "1288880" on hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e3"
+    Then hearing note with id "1288880" on hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e3" should have a textarea with a save button and cancel link
+
   Scenario: Display hearing notes
     Given I am an authenticated user
     And I click the "Accept analytics cookies" button
@@ -129,6 +156,7 @@ Feature: Case progress
 
     And I should see a "m" sized level 3 heading with text "Case progress"
     And I should see 6 previous hearings headers
+    And I should see header on hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e7" with outcome "Adjourned" date "Monday 24 April 2023" and edit link
     And I should see below notes on hearing "2aa6f5e0-f842-4939-bc6a-01346abc09e7" with author datetime and note with edit and delete links
       | John Doe    | 9 August 2022, 17:16  | Result: 6 months Community Order 10 RAR UPW - 50hrs court costs induction required at local office.   |
       | Jane Smith  | 9 July 2022, 17:13    | Result: 12 months Community Order 10 RAR UPW - 100hrs court costs induction required at local office. |

--- a/integration-tests/cypress/e2e/case-progress/steps.js
+++ b/integration-tests/cypress/e2e/case-progress/steps.js
@@ -12,9 +12,34 @@ Then('I click delete hearing note with id {string} on hearing {string}', ($noteI
   })
 })
 
+Then('I click edit hearing note with id {string} on hearing {string}', ($noteId, $hearingId) => {
+  cy.get(`#case-progress-hearing-${$hearingId}`).within(() => {
+    cy.get(`#previous-note-${$noteId}`).within(() => {
+      cy.get('.note-edit-link').click()
+    })
+  })
+})
+
+Then('hearing note with id {string} on hearing {string} should have a textarea with a save button and cancel link', ($noteId, $hearingId) => {
+  cy.get(`#case-progress-hearing-${$hearingId}`).within(() => {
+    cy.get(`#previous-note-${$noteId}`).within(() => {
+      cy.get('textarea').should('exist')
+      cy.get('.hearing-note-edit-done').should('exist').and('contain.text', 'Save')
+      cy.get('.note-edit-cancel-link').should('exist').and('contain.text', 'Cancel')
+    })
+  })
+})
+
 Then('hearing {string} should have a draft note with text {string}', ($hearingId, $draftNote) => {
   cy.get(`#case-progress-hearing-${$hearingId}`).within(() => {
     cy.get(`#note-box-${$hearingId}`).should('have.value', $draftNote)
+  })
+})
+
+Then('I should see header on hearing {string} with outcome {string} date {string} and edit link', ($hearingId, $outcome, $date) => {
+  cy.get(`#case-progress-hearing-${$hearingId}`).within(() => {
+    cy.get('.app-summary-card__banner').should('contain.text', $outcome).and('contain.text', `Sent to admin on ${$date}`)
+    cy.get('.hearing-outcome-edit').should('have.text', 'Edit')
   })
 })
 
@@ -29,6 +54,13 @@ Then('I should see below notes on hearing {string} with author datetime and note
     })
   })
 })
+
+Then('I should see "Send outcome to admin" button on hearing with id {string}', ($hearingId) => {
+  cy.get(`#case-progress-hearing-${$hearingId}`).within(() => {
+    cy.get('.btn-send-hearing-outcome').should('exist')
+  })
+})
+
 
 Then('I should see a warning banner on hearing {string} with text {string}', ($hearingId, $string) => {
   cy.get(`#case-progress-hearing-${$hearingId} .hearing-note-container`).eq(0).within(() => {
@@ -48,7 +80,7 @@ Then('I should see {string} link on hearing with id {string}', ($title, $hearing
   })
 })
 
-Then('I should see a text area wih label Add information specific to this hearing on hearing with id {string}', $hearingId => {
+Then('I should see a text area with label Add information specific to this hearing on hearing with id {string}', $hearingId => {
   cy.get(`#case-progress-hearing-${$hearingId}`).within(() => {
     cy.get('.govuk-details__text').within(() => {
       cy.get('label').should('contain.text', 'Add information specific to this hearing')
@@ -63,9 +95,9 @@ Then('I should see a Save button on hearing with id {string}', $hearingId => {
   })
 })
 
-Then('I should see a Cancel link on hearing with id {string}', $hearingId => {
+Then('I click the Save button on hearing with id {string}', $hearingId => {
   cy.get(`#case-progress-hearing-${$hearingId}`).within(() => {
-    cy.get('.govuk-details__text a').should('have.text', 'Cancel')
+    cy.get('.govuk-details__text button').contains('Save').click()
   })
 })
 
@@ -102,32 +134,6 @@ Then('I should see the following hearings with the hearing type label, hearing d
 
 Then('I should see a bottom border on all notes within a hearing', () => {
   cy.get('.app-summary-card [data-test="note-td"]').should('have.css', 'border-bottom', '1px solid rgb(177, 180, 182)')
-})
-
-Then('the note with the id {string} on hearing {string} is filled with the text {string}', ($noteId, $hearingId) => {
-  cy.get(`#case-progress-hearing-${$hearingId}`).within(() => {
-    cy.get(`#previous-note-${$noteId}`).should('exist')
-  })
-})
-
-Then('the user should be alerted with a popup', () => {
-  cy.get('.popup-toggle').should('exist')
-})
-
-Then('I should see a warning icon', () => {
-  cy.get('.govuk-warning-text__icon').should('exist')
-})
-
-Then('I should see the text heading message {string}', $string => {
-  cy.get('.govuk-warning-text__text').contains($string)
-})
-
-Then('I should see the text body message {string}', $string => {
-  cy.get('.govuk-body-s').contains($string)
-})
-
-Then('I click the {string} button to be back on my page', $string => {
-  cy.get('#close-btn').contains($string).click({ force: true })
 })
 
 Then('I should {string} line breaks on hearing note {string}', ($expected, $noteId) => {

--- a/integration-tests/cypress/e2e/case-summary-comments.feature
+++ b/integration-tests/cypress/e2e/case-summary-comments.feature
@@ -82,16 +82,6 @@ Feature: Case comments
     Then I should be on the "Case summary" page
     And I should see govuk notification banner with header "Success" and message "You successfully deleted a comment"
 
-    Then I click "Delete" on the below comment located in table row 5
-      | Comment One     | Adam Sandler on 9 August 2022, 17:17 |
-    Then I should see the heading "Are you sure you want to delete this comment?"
-    And I should see the text "Added on the 9 August 2022, 17:17" within element with class "govuk-caption-m"
-    And I should see a button with the label "Delete comment"
-    And I should see link "Cancel" with href "/B14LO/hearing/5b9c8c1d-e552-494e-bc90-d475740c64d8/defendant/8597a10b-d330-43e5-80c3-27ce3b46979f/summary#previousComments"
-    Then I click the "Cancel" link
-    Then I should be on the "Case summary" page
-    And I should not see govuk notification banner
-
   Scenario: Cancel a delete comment attempt
     Given I am an authenticated user
     And I click the "Accept analytics cookies" button
@@ -123,18 +113,15 @@ Feature: Case comments
     When I enter a comment "a comment" in the comment box
     And I click the button to "Save" comment
     Then I should NOT see an error message
+    And I should see govuk notification banner with header "Success" and message "You successfully added a comment"
 
-  Scenario: Should be able to edit a comment
+  Scenario: Should be able to cancel an edit comment attempt
     Given I am an authenticated user
     And I click the "Accept analytics cookies" button
     Then I should not see the cookie banner
 
     When I navigate to the "/B14LO/hearing/5b9c8c1d-e552-494e-bc90-d475740c64d8/defendant/8597a10b-d330-43e5-80c3-27ce3b46979f/summary" base route
     Then I should be on the "Case summary" page
-
-    When I enter a comment "a comment" in the comment box
-    And I click the button to "Save" comment
-    Then I should NOT see an error message
 
     And I click "Edit" on the below comment located in table row 5
       | Comment One     | Adam Sandler on 9 August 2022, 17:17 |

--- a/integration-tests/cypress/e2e/case-summary-comments/steps.js
+++ b/integration-tests/cypress/e2e/case-summary-comments/steps.js
@@ -10,14 +10,6 @@ When('I click the button to {string} comment', $string => {
   cy.get('#save-comments').contains($string).click()
 })
 
-Then('I should see the comments textarea highlighted as error', () => {
-  cy.get('#comment').should('have.class', 'govuk-textarea--error')
-})
-
-Then('I should see an error message {string}', $string => {
-  cy.get('#comment-error').should('include.text', $string)
-})
-
 Then('I should NOT see an error message', $string => {
   cy.get('#comment-error').should('not.exist')
 })
@@ -67,7 +59,7 @@ Then('I click {string} on the below comment located in table row {int}', ($link,
   })
 })
 
-Then('I click {string} on the edit textarea in row {int}', ($string, $int) => {
+Then('I click "Cancel" on the edit textarea in row {int}', ($int) => {
   getCommentsRow($int).within(() => {
     cy.get('.govuk-table__cell').eq(0).within(() => {
       cy.get('.case-comment-edit-container').should('be.visible').within(() => {

--- a/server/routes/handlers/caseSummary.js
+++ b/server/routes/handlers/caseSummary.js
@@ -26,7 +26,9 @@ const caseSummaryHandler = utils => async (req, res) => {
     ...session
   }
   session.deleteCommentSuccess = undefined
+  session.addCommentSuccess = undefined
   session.deleteHearingNoteSuccess = undefined
+  session.addHearingNoteSuccess = undefined
   session.addHearingOutcomeSuccess = undefined
   session.editHearingOutcomeSuccess = undefined
   session.assignHearingOutcomeSuccess = undefined

--- a/server/routes/handlers/getAddCommentRequestHandler.js
+++ b/server/routes/handlers/getAddCommentRequestHandler.js
@@ -7,6 +7,7 @@ const getAddCaseCommentHandler = caseService => async (req, res) => {
     session.caseCommentBlankError = true
   } else {
     await caseService.addCaseComment(caseId, defendantId, comment, res.locals.user.name)
+    session.addCommentSuccess = caseId
 
     if (!res.locals.user.name) {
       trackEvent('PiCAddCaseCommentNoName', res.locals.user)

--- a/server/routes/handlers/getAddHearingNoteRequestHandler.js
+++ b/server/routes/handlers/getAddHearingNoteRequestHandler.js
@@ -3,7 +3,8 @@ const trackEvent = require('../../utils/analytics')
 const getAddHearingNoteHandler = caseService => async (req, res) => {
   const {
     params: { courtCode, hearingId, defendantId },
-    body: { note, hearingId: targetHearingId }
+    body: { note, hearingId: targetHearingId },
+    session
   } = req
 
   if (note) {
@@ -13,11 +14,12 @@ const getAddHearingNoteHandler = caseService => async (req, res) => {
       res.locals.user.name,
       defendantId
     )
+    session.addHearingNoteSuccess = targetHearingId
     if (!res.locals.user.name) {
       trackEvent('PiCAddHearingNoteNoName', res.locals.user)
     }
   }
-
+  
   res.redirect(
     `/${courtCode}/hearing/${hearingId}/defendant/${defendantId}/summary#case-progress-hearing-${targetHearingId}`
   )

--- a/server/routes/handlers/getAddHearingNoteRequestHandler.js
+++ b/server/routes/handlers/getAddHearingNoteRequestHandler.js
@@ -19,7 +19,7 @@ const getAddHearingNoteHandler = caseService => async (req, res) => {
       trackEvent('PiCAddHearingNoteNoName', res.locals.user)
     }
   }
-  
+
   res.redirect(
     `/${courtCode}/hearing/${hearingId}/defendant/${defendantId}/summary#case-progress-hearing-${targetHearingId}`
   )

--- a/server/views/case-summary/case-summary.njk
+++ b/server/views/case-summary/case-summary.njk
@@ -48,6 +48,19 @@
         }) }}
     {% endif %}
 
+    {% if session.addHearingNoteSuccess %}
+        {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+        {% set html %}
+            <p class="govuk-notification-banner__heading">
+                You successfully added a note
+            </p>
+        {% endset %}
+        {{ govukNotificationBanner({
+            html: html,
+            type: 'success'
+        }) }}
+    {% endif %}
+
     {% if session.addHearingOutcomeSuccess %}
         {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
         {% set html %}

--- a/server/views/court-case-comments.njk
+++ b/server/views/court-case-comments.njk
@@ -15,6 +15,20 @@
                 classes: 'case-comments-delete-success-notification'
             }) }}
         {% endif %}
+
+        {% if session.addCommentSuccess === data.caseId %}
+            {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+            {% set html %}
+                <span class="govuk-body-l">
+                        You successfully added a comment
+                    </span>
+            {% endset %}
+            {{ govukNotificationBanner({
+                html: html,
+                type: 'success'
+            }) }}
+        {% endif %}
+
         <div class="govuk-form-group govuk-!-margin-bottom-7">
             <div id="comments-hint">
                 <p id="comments-hint-p1" class="govuk-body">

--- a/tests/routes/handlers/getAddCommentRequestHandler.test.js
+++ b/tests/routes/handlers/getAddCommentRequestHandler.test.js
@@ -24,6 +24,7 @@ describe('getAddCommentRequestHandler', () => {
     await subject(mockRequest, mockResponse)
 
     // Then
+    expect(mockRequest.session.addCommentSuccess).toEqual(testCaseId)
     expect(caseServiceMock.addCaseComment).toHaveBeenLastCalledWith(testCaseId, 'test-defendant-id', 'A comment', 'Adam Sandler')
     expect(mockResponse.redirect).toHaveBeenCalledWith(`/${courtCode}/hearing/${testHearingId}/defendant/${testDefendantId}/summary#caseComments`)
   })

--- a/tests/routes/handlers/getAddHearingNoteRequestHandler.test.js
+++ b/tests/routes/handlers/getAddHearingNoteRequestHandler.test.js
@@ -18,7 +18,8 @@ describe('getAddNoteRequestHandler', () => {
       courtCode
     },
     body: { hearingId: testHearingId, note: 'A note' },
-    path: '/test/path'
+    path: '/test/path',
+    session: {}
   }
 
   it('should invoke add hearing note and render case summary note', async () => {
@@ -26,6 +27,7 @@ describe('getAddNoteRequestHandler', () => {
     await subject(mockRequest, mockResponse)
 
     // Then
+    expect(mockRequest.session.addHearingNoteSuccess).toEqual(testHearingId)
     expect(caseServiceMock.addHearingNote).toHaveBeenCalledWith(
       testHearingId,
       'A note',


### PR DESCRIPTION
Show success banner when adding a note or comment on a case

Update cypress tests to reflect this and remove some duplicate and unused test code

Success banner when adding a note:
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/9a1925f2-b4df-4f32-9b6c-981b180d2b06" />

Success banner when adding a comment:
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/72f510f8-ba39-4f93-9758-38b387617862" />
