### PR TITLE
PIC-4537: improve heading hierarchy - probation record and risk register

### DIFF
--- a/integration-tests/cypress/e2e/case-summary.feature
+++ b/integration-tests/cypress/e2e/case-summary.feature
@@ -301,7 +301,7 @@ Feature: Case summary
     And I should see the body text "Noise offences - 82200"
     And I should see the hint text "Offence committed on 6 January 2021"
     And I should see a level 1 heading with text "Webb Mitchell"
-    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see a "l" sized level 2 heading with text "Probation record"
     And I should see the following "m" sized level 2 headings
       | Pre-sentence report requested | Current orders | Previous orders | Last OASys assessment |
     And There should be no a11y violations
@@ -318,7 +318,7 @@ Feature: Case summary
     And I click the sub navigation with "Probation record" text
 
     Then I should see a level 1 heading with text "Lenore Marquez"
-    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see a "l" sized level 2 heading with text "Probation record"
     And I should see the following "m" sized level 2 headings
       | Pre-sentence report requested | Current orders | Previous orders | Offender manager | Last pre-sentence report | Last OASys assessment |
 
@@ -462,7 +462,7 @@ Feature: Case summary
     And I should see the following "m" sized level 3 headings
       | Defendant details | Case documents | Appearance | Offences | Case progress | Comments |
     When I click the sub navigation with "Probation record" text
-    Then I should see the heading "You are restricted from viewing this record"
+    Then I should see a "l" sized level 2 heading with text "You are restricted from viewing this record"
 
     And I should see the body text "You cannot view probation information for this defendant due to restrictions on your NDelius account."
     And I should see the body text "If you think you should be able to view this case, contact your line manager."
@@ -475,7 +475,7 @@ Feature: Case summary
     When I navigate to the "/B14LO/hearing/4e10a261-2d0f-4b07-a684-e2b03ee54a4f/defendant/cf6ce65e-48f9-4b62-9d39-67fbfe68e9fc/record" base route
     Then I should be on the "Probation record" page
     And I should see a level 1 heading with text "Lenore Marquez"
-    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see a "l" sized level 2 heading with text "Probation record"
     And I should see the following "m" sized level 2 headings
       | Pre-sentence report requested | Current orders | Previous orders | Last OASys assessment |
 
@@ -607,7 +607,7 @@ Feature: Case summary
     When I navigate to the "/B14LO/hearing/8d187ea4-d24d-4806-a5c7-1626919c44bb/defendant/9f60bdb8-0978-404c-bd89-addc3f5388a7/record" base route
     Then I should be on the "Probation record" page
     And I should see a level 1 heading with text "Olsen Alexander"
-    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see a "l" sized level 2 heading with text "Probation record"
     And I should see the following "m" sized level 2 headings
       | Current orders | Previous orders | Offender manager | Last pre-sentence report | Last OASys assessment |
 
@@ -710,7 +710,7 @@ Feature: Case summary
     When I navigate to the "/B14LO/hearing/4e10a261-2d0f-4b07-a684-e2b03ee54a4f/defendant/cf6ce65e-48f9-4b62-9d39-67fbfe68e9fc/record" base route
     Then I should be on the "Probation record" page
     And I should see a level 1 heading with text "Lenore Marquez"
-    And I should see a "l" sized level 1 heading with text "Probation record"
+    And I should see a "l" sized level 2 heading with text "Probation record"
     And I should see the following "m" sized level 2 headings
       | Pre-sentence report requested | Current orders | Previous orders | Last OASys assessment |
 
@@ -824,7 +824,7 @@ Feature: Case summary
 
     When I click the "English Madden" link
     And I click the sub navigation with "Risk register" text
-    And I should see the heading "You are restricted from viewing this record"
+    And I should see a "l" sized level 2 heading with text "You are restricted from viewing this record"
 
     And I should see the body text "You cannot view probation information for this defendant due to restrictions on your NDelius account."
     And I should see the body text "If you think you should be able to view this case, contact your line manager."

--- a/integration-tests/cypress/support/step_definitions/headings.js
+++ b/integration-tests/cypress/support/step_definitions/headings.js
@@ -20,10 +20,6 @@ Then('I should not see the heading level {int} with text {string}', ($level, $te
   cy.get(`h${$level}`).contains($text).should('not.exist')
 })
 
-Then('I should see a {string} sized level {int} heading with the text {string}', ($size, $level, $text) => {
-  cy.get(`h${$level} .govuk-heading-${$size}`).contains($text).should('exist')
-})
-
 Then('I should see a level {int} heading with text {string}', ($level, $text) => {
     cy.get(`h${$level}`).contains($text).should('exist')
 })

--- a/server/views/case-summary/case-summary-record.njk
+++ b/server/views/case-summary/case-summary-record.njk
@@ -29,9 +29,9 @@
 
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
-                    <h1 class="govuk-heading-l">
+                    <h2 class="govuk-heading-l">
                         {{ "You are restricted from viewing this record" if communityData.status === 403 else "Probation record" }}
-                    </h1>
+                    </h2>
                 </div>
             </div>
 

--- a/server/views/case-summary/case-summary-risk.njk
+++ b/server/views/case-summary/case-summary-risk.njk
@@ -18,7 +18,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
 
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ "You are restricted from viewing this record" if forbidden else "Risk register" }}</h1>
+            <h2 class="govuk-heading-l govuk-!-margin-bottom-7">{{ "You are restricted from viewing this record" if forbidden else "Risk register" }}</h2>
 
             {% if forbidden %}
                 <p class="govuk-body">{{ riskData.userMessage }}</p>


### PR DESCRIPTION
- Changed the headings "Probation Record" and "Risk Register" from h1 to h2 - retained the same styling so no visible change.
- Updated Cypress tests to reflect this.