### PR TITLE
include visual label in accessible label for datepicker

### DIFF
--- a/server/views/components/days-navigation/template.njk
+++ b/server/views/components/days-navigation/template.njk
@@ -28,7 +28,7 @@
                 {%- endif -%}
                 {%- set isCurrentDateOrSunday = isCurrentDate or isSunday -%}
 
-                <{{ "span" if isCurrentDateOrSunday else "a" }} class="splide__slide pac-days-navigation-item{{ " pac-days-navigation-item__link" if not isCurrentDateOrSunday }}{{ " calendar-nav-link-today" if params.enablePastCasesNavigation and isToday and not isCurrentDate }}{{ " calendar-nav-link__disabled" if isSunday }}"{% if not isCurrentDateOrSunday %} href="{{ params.baseUrl + '/' + thisDate.format('yyyy-MM-DD') }}"{% elseif isCurrentDate %} aria-current="date"{% endif %} aria-label="{{ thisDate.format('dddd D')}}" role="group" aria-roledescription="slide">
+                <{{ "span" if isCurrentDateOrSunday else "a" }} class="splide__slide pac-days-navigation-item{{ " pac-days-navigation-item__link" if not isCurrentDateOrSunday }}{{ " calendar-nav-link-today" if params.enablePastCasesNavigation and isToday and not isCurrentDate }}{{ " calendar-nav-link__disabled" if isSunday }}"{% if not isCurrentDateOrSunday %} href="{{ params.baseUrl + '/' + thisDate.format('yyyy-MM-DD') }}"{% elseif isCurrentDate %} aria-current="date"{% endif %} aria-label="View case list for {{ thisDate.format('ddd D')}}" role="group" aria-roledescription="slide">
 
                     <span>{{ thisDate.format('ddd') }}</span>
                     <span class="govuk-!-font-size-24 govuk-!-font-weight-bold">{{ thisDate.format('D') }}</span>


### PR DESCRIPTION
Changed accessible names on datepicker to include visual label i.e. "Fri 29" rather than "Friday 29" as per recommendation from accessibility audit, to ensure compatibility with ATs.

Before:
![image](https://github.com/user-attachments/assets/b052c955-0913-42eb-b28e-9dce48ecc449)

Now:
<img width="842" alt="image" src="https://github.com/user-attachments/assets/b0b2ae35-0097-4e5a-8f12-aacbc3a1dff1" />
