### PR TITLE
remove inconsistent success banners when adding hearing note/comment

### DIFF
--- a/integration-tests/cypress/e2e/case-progress.feature
+++ b/integration-tests/cypress/e2e/case-progress.feature
@@ -22,9 +22,6 @@ Feature: Case progress
     And I should see a Save button on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
     And I should see a Cancel saving note link on hearing with id "f26d6d4e-b987-417e-8323-18009ee001af"
 
-    When I click the Save button on hearing with id "2aa6f5e0-f842-4939-bc6a-01346abc09e7"
-    Then I should see govuk notification banner with header "Success" and message "You successfully added a note"
-
   Scenario: View hearing note on the case summary page
     Given I am an authenticated user
     And I click the "Accept analytics cookies" button

--- a/integration-tests/cypress/e2e/case-summary-comments.feature
+++ b/integration-tests/cypress/e2e/case-summary-comments.feature
@@ -113,7 +113,6 @@ Feature: Case comments
     When I enter a comment "a comment" in the comment box
     And I click the button to "Save" comment
     Then I should NOT see an error message
-    And I should see govuk notification banner with header "Success" and message "You successfully added a comment"
 
   Scenario: Should be able to cancel an edit comment attempt
     Given I am an authenticated user

--- a/server/routes/handlers/caseSummary.js
+++ b/server/routes/handlers/caseSummary.js
@@ -26,9 +26,7 @@ const caseSummaryHandler = utils => async (req, res) => {
     ...session
   }
   session.deleteCommentSuccess = undefined
-  session.addCommentSuccess = undefined
   session.deleteHearingNoteSuccess = undefined
-  session.addHearingNoteSuccess = undefined
   session.addHearingOutcomeSuccess = undefined
   session.editHearingOutcomeSuccess = undefined
   session.assignHearingOutcomeSuccess = undefined

--- a/server/routes/handlers/getAddCommentRequestHandler.js
+++ b/server/routes/handlers/getAddCommentRequestHandler.js
@@ -7,7 +7,6 @@ const getAddCaseCommentHandler = caseService => async (req, res) => {
     session.caseCommentBlankError = true
   } else {
     await caseService.addCaseComment(caseId, defendantId, comment, res.locals.user.name)
-    session.addCommentSuccess = caseId
 
     if (!res.locals.user.name) {
       trackEvent('PiCAddCaseCommentNoName', res.locals.user)

--- a/server/routes/handlers/getAddHearingNoteRequestHandler.js
+++ b/server/routes/handlers/getAddHearingNoteRequestHandler.js
@@ -3,8 +3,7 @@ const trackEvent = require('../../utils/analytics')
 const getAddHearingNoteHandler = caseService => async (req, res) => {
   const {
     params: { courtCode, hearingId, defendantId },
-    body: { note, hearingId: targetHearingId },
-    session
+    body: { note, hearingId: targetHearingId }
   } = req
 
   if (note) {
@@ -14,7 +13,6 @@ const getAddHearingNoteHandler = caseService => async (req, res) => {
       res.locals.user.name,
       defendantId
     )
-    session.addHearingNoteSuccess = targetHearingId
     if (!res.locals.user.name) {
       trackEvent('PiCAddHearingNoteNoName', res.locals.user)
     }

--- a/server/views/case-summary/case-summary.njk
+++ b/server/views/case-summary/case-summary.njk
@@ -48,19 +48,6 @@
         }) }}
     {% endif %}
 
-    {% if session.addHearingNoteSuccess %}
-        {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-        {% set html %}
-            <p class="govuk-notification-banner__heading">
-                You successfully added a note
-            </p>
-        {% endset %}
-        {{ govukNotificationBanner({
-            html: html,
-            type: 'success'
-        }) }}
-    {% endif %}
-
     {% if session.addHearingOutcomeSuccess %}
         {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
         {% set html %}

--- a/server/views/court-case-comments.njk
+++ b/server/views/court-case-comments.njk
@@ -16,19 +16,6 @@
             }) }}
         {% endif %}
 
-        {% if session.addCommentSuccess === data.caseId %}
-            {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-            {% set html %}
-                <span class="govuk-body-l">
-                        You successfully added a comment
-                    </span>
-            {% endset %}
-            {{ govukNotificationBanner({
-                html: html,
-                type: 'success'
-            }) }}
-        {% endif %}
-
         <div class="govuk-form-group govuk-!-margin-bottom-7">
             <div id="comments-hint">
                 <p id="comments-hint-p1" class="govuk-body">

--- a/tests/routes/handlers/getAddCommentRequestHandler.test.js
+++ b/tests/routes/handlers/getAddCommentRequestHandler.test.js
@@ -24,7 +24,6 @@ describe('getAddCommentRequestHandler', () => {
     await subject(mockRequest, mockResponse)
 
     // Then
-    expect(mockRequest.session.addCommentSuccess).toEqual(testCaseId)
     expect(caseServiceMock.addCaseComment).toHaveBeenLastCalledWith(testCaseId, 'test-defendant-id', 'A comment', 'Adam Sandler')
     expect(mockResponse.redirect).toHaveBeenCalledWith(`/${courtCode}/hearing/${testHearingId}/defendant/${testDefendantId}/summary#caseComments`)
   })

--- a/tests/routes/handlers/getAddHearingNoteRequestHandler.test.js
+++ b/tests/routes/handlers/getAddHearingNoteRequestHandler.test.js
@@ -18,8 +18,7 @@ describe('getAddNoteRequestHandler', () => {
       courtCode
     },
     body: { hearingId: testHearingId, note: 'A note' },
-    path: '/test/path',
-    session: {}
+    path: '/test/path'
   }
 
   it('should invoke add hearing note and render case summary note', async () => {
@@ -27,7 +26,6 @@ describe('getAddNoteRequestHandler', () => {
     await subject(mockRequest, mockResponse)
 
     // Then
-    expect(mockRequest.session.addHearingNoteSuccess).toEqual(testHearingId)
     expect(caseServiceMock.addHearingNote).toHaveBeenCalledWith(
       testHearingId,
       'A note',


### PR DESCRIPTION
Remove success banners which appear when adding a hearing note or comment, added as part of PIC-3148.

Following a discussion with UX, these are not to be deployed to prod due to inconsistency.