### PR TITLE
replace google feedback forms with new links

### DIFF
--- a/integration-tests/cypress/e2e/accessibility-statement.feature
+++ b/integration-tests/cypress/e2e/accessibility-statement.feature
@@ -11,8 +11,8 @@ Feature: Accessibility statement
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
 
     Then I should see the heading "Accessibility statement"
     And There should be no a11y violations

--- a/integration-tests/cypress/e2e/case-list.feature
+++ b/integration-tests/cypress/e2e/case-list.feature
@@ -11,8 +11,8 @@ Feature: Case list
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
 
     And I should see the caption with the court name "Sheffield Magistrates' Court"
     And I should see the current day as "Today"

--- a/integration-tests/cypress/e2e/case-summary.feature
+++ b/integration-tests/cypress/e2e/case-summary.feature
@@ -11,8 +11,8 @@ Feature: Case summary
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
 
     And I should see the caption with the court name "Sheffield Magistrates' Court"
     When I click the "Kara Ayers" link

--- a/integration-tests/cypress/e2e/cases-in-progress-list.feature
+++ b/integration-tests/cypress/e2e/cases-in-progress-list.feature
@@ -15,7 +15,7 @@ Feature: Cases in Progress List
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
 
     And I should see a tab with text "Cases to result (8)"
 

--- a/integration-tests/cypress/e2e/cases-outcome-resulted.feature
+++ b/integration-tests/cypress/e2e/cases-outcome-resulted.feature
@@ -15,7 +15,7 @@ Feature: Resulted Cases List
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
 
     Then I click the "Resulted cases" link
 

--- a/integration-tests/cypress/e2e/cases-to-result-list.feature
+++ b/integration-tests/cypress/e2e/cases-to-result-list.feature
@@ -14,7 +14,7 @@ Feature: Cases to Result List
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
 
     And I should see a tab with text "Cases to result (80)"
 

--- a/integration-tests/cypress/e2e/cookies-policy.feature
+++ b/integration-tests/cypress/e2e/cookies-policy.feature
@@ -11,8 +11,8 @@ Feature: Accessibility statement
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
 
     Then I should see the heading "Cookies"
     And I should see the following level 2 headings

--- a/integration-tests/cypress/e2e/matching.feature
+++ b/integration-tests/cypress/e2e/matching.feature
@@ -12,8 +12,8 @@ Feature: Matching defendants to nDelius records
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
 
     And I should see the heading "Defendants with possible NDelius records"
 

--- a/integration-tests/cypress/e2e/outcomes.feature
+++ b/integration-tests/cypress/e2e/outcomes.feature
@@ -14,8 +14,8 @@ Feature: Outcomes List
     Then I should be on the "Hearing outcomes" page
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
     And I should see a tab with text "Cases to result"
     And I should see a tab with text "In progress"
     And I should see a tab with text "Resulted cases"

--- a/integration-tests/cypress/e2e/privacy-notice.feature
+++ b/integration-tests/cypress/e2e/privacy-notice.feature
@@ -11,8 +11,8 @@ Feature: Privacy notice
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
 
     Then I should see the heading "Privacy notice"
     And There should be no a11y violations

--- a/integration-tests/cypress/e2e/select-court.feature
+++ b/integration-tests/cypress/e2e/select-court.feature
@@ -10,8 +10,8 @@ Feature: Select court
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
 
     And I should see the body text "Add and save the courts you work in to view case lists for those courts."
     And There should be no a11y violations

--- a/integration-tests/cypress/e2e/user-guide.feature
+++ b/integration-tests/cypress/e2e/user-guide.feature
@@ -11,8 +11,8 @@ Feature: User guide
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
 
     And I should see the text "Overview" in a list
     And I should see link "Overview" with href "#ug-overview"

--- a/integration-tests/cypress/e2e/whats-new.feature
+++ b/integration-tests/cypress/e2e/whats-new.feature
@@ -11,8 +11,8 @@ Feature: What's new
 
     And I should see the phase banner
     And I should see the tag "Feedback"
-    And I should see phase banner link "Give us your feedback" with href "https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link"
-    And I should see phase banner link "report a bug" with href "https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1"
+    And I should see phase banner link "Give us your feedback" with href "https://www.smartsurvey.co.uk/s/NMOI4O/"
+    And I should see phase banner link "report a bug" with href "https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b"
     And I should see back link "Back" with href "/"
 
     Then I should see the heading "What's new"

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -141,7 +141,7 @@
       tag: {
         text: "Feedback"
       },
-      html: '<a class="govuk-link govuk-link--no-visited-state" href="https://docs.google.com/forms/d/e/1FAIpQLScluoDOXsJ_XBO3iOp283JE9mN3vTVNgEJcPNDHQQvU-dbHuA/viewform?usp=sf_link" rel="noreferrer" target="_blank">Give us your feedback</a> or <a class="govuk-link govuk-link--no-visited-state" href="https://docs.google.com/forms/d/e/1FAIpQLSfLqoIFzPIivFNJwCvQPcw6L_fUkbTY6RNqgzrIpN4XGKBqpA/viewform?pli=1" rel="noreferrer" target="_blank">report a bug</a> to help us improve this service.'
+      html: '<a class="govuk-link govuk-link--no-visited-state" href="https://www.smartsurvey.co.uk/s/NMOI4O/" rel="noreferrer" target="_blank">Give us your feedback</a> or <a class="govuk-link govuk-link--no-visited-state" href="https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=2659ea2b1b600a1425dc6351f54bcb7b" rel="noreferrer" target="_blank">report a bug</a> to help us improve this service.'
     }) }}
   </div>
 {% endblock %}


### PR DESCRIPTION
Migrates the feedback and bug forms from Google to Smart Survey and ServiceNow respectively. Update tests to reflect new URLs.
<img width="603" alt="image" src="https://github.com/user-attachments/assets/38baa3f3-1902-493e-a9d1-05a49e2fdd06" />
