### PR TITLE
use moj pagination in pac

### DIFF
--- a/integration-tests/cypress/e2e/case-list.feature
+++ b/integration-tests/cypress/e2e/case-list.feature
@@ -50,6 +50,7 @@ Feature: Case list
     And I should see pagination link "2" with href "page=2"
     And I should see pagination link "3" with href "page=3"
     And I should see pagination next link with href "page=2"
+    And I should see pagination text "Showing 1 to 20 of 80 results"
     And There should be no a11y violations
 
   Scenario: View specific offence data on the case list
@@ -110,6 +111,7 @@ Feature: Case list
     And I should see pagination link "3" with href "page=3"
     And I should see pagination link "4" with href "page=4"
     And I should see pagination next link with href "page=3"
+    And I should see pagination text "Showing 21 to 40 of 80 results"
     And There should be no a11y violations
 
   Scenario: View the recently added cases on the case list
@@ -136,6 +138,7 @@ Feature: Case list
     And I should see pagination page "1" highlighted
     And I should see pagination link "2" with href "added?page=2"
     And I should see pagination next link with href "added?page=2"
+    And I should see pagination text "Showing 1 to 20 of 80 results"
     And There should be no a11y violations
 
     # Test state held in session

--- a/integration-tests/cypress/e2e/case-search.feature
+++ b/integration-tests/cypress/e2e/case-search.feature
@@ -57,6 +57,7 @@ Feature: Case search
     When I enter "C123456" into text input with id "search-term"
     And I click the "Search" button
     Then I should see the level 3 heading "125 search results for C123456"
+    And I should see pagination text "Showing 1 to 20 of 125 results"
     And I should see pagination
     And I should not see pagination previous link
     And I should see pagination page "1" highlighted
@@ -67,6 +68,7 @@ Feature: Case search
 
     When I click pagination next link
     Then the page 2 should be loaded
+    And I should see pagination text "Showing 21 to 40 of 125 results"
     And I should see pagination previous link with href "page=1"
     And I should see pagination link "1" with href "page=1"
     And I should see pagination page "2" highlighted
@@ -78,6 +80,7 @@ Feature: Case search
     When I click pagination next link
     Then I click pagination link "4"
     Then the page 4 should be loaded
+    And I should see pagination text "Showing 61 to 80 of 125 results"
     And I should see pagination previous link with href "page=3"
     And I should see pagination link "1" with href "page=1"
     And I should see pagination link "2" with href "page=2"

--- a/integration-tests/cypress/e2e/cases-in-progress-list.feature
+++ b/integration-tests/cypress/e2e/cases-in-progress-list.feature
@@ -31,6 +31,7 @@ Feature: Cases in Progress List
 
     And I should see pagination
     And I should not see pagination previous link
+    And I should see pagination text "Showing 1 to 2 of 21 results"
     And I should see pagination page "1" highlighted
     And I should see pagination link "2" with href "page=2"
     And I should see pagination next link with href "page=2"

--- a/integration-tests/cypress/e2e/cases-outcome-resulted.feature
+++ b/integration-tests/cypress/e2e/cases-outcome-resulted.feature
@@ -33,6 +33,7 @@ Feature: Resulted Cases List
       | English Madden | Adjourned        | Previously known | Attempt theft from the person of another | 5 Sep 2023 | Johnny Ball \n on 9 Sep 2023 at 14:16 |
 
     And I should see pagination
+    And I should see pagination text "Showing 1 to 2 of 21 results"
     And I should not see pagination previous link
     And I should see pagination page "1" highlighted
     And I should see pagination link "2" with href "page=2"

--- a/integration-tests/cypress/e2e/cases-to-result-list.feature
+++ b/integration-tests/cypress/e2e/cases-to-result-list.feature
@@ -26,6 +26,7 @@ Feature: Cases to Result List
     And I should see the following table rows
       |  | Gill Arnold    | Report requested | Current          | Offence title one                        | 5 Jul 2023 |
       |  | English Madden | Adjourned        | Previously known | Attempt theft from the person of another | 5 Sep 2023 |
+    And I should see pagination text "Showing 1 to 2 of 80 results"
     And I should see pagination page "1" highlighted
     And I should see pagination link "2" with href "page=2"
     And I should see pagination link "3" with href "page=3"
@@ -34,6 +35,7 @@ Feature: Cases to Result List
 
     When I click pagination next link
     Then the page 2 should be loaded
+    And I should see pagination text "Showing 3 to 4 of 80 results"
     And I should see pagination previous link with href "page=1"
     And I should see pagination link "1" with href "page=1"
     And I should see pagination page "2" highlighted
@@ -46,6 +48,7 @@ Feature: Cases to Result List
 
     When I click pagination next link
     Then the page 3 should be loaded
+    And I should see pagination text "Showing 5 to 6 of 80 results"
     And I should see pagination previous link with href "page=2"
     And I should see pagination link "1" with href "page=1"
     And I should see pagination link "2" with href "page=2"
@@ -58,6 +61,7 @@ Feature: Cases to Result List
 
     When I click pagination previous link
     Then the page 2 should be loaded
+    And I should see pagination text "Showing 3 to 4 of 80 results"
     And I should see pagination previous link with href "page=1"
     And I should see pagination link "1" with href "page=1"
     And I should see pagination page "2" highlighted

--- a/integration-tests/cypress/support/step_definitions/common.js
+++ b/integration-tests/cypress/support/step_definitions/common.js
@@ -585,57 +585,57 @@ Then('I should see the {string} filter tag', $string => {
 })
 
 Then('I should see pagination', () => {
-  cy.get('.govuk-pagination').should('exist')
+  cy.get('.moj-pagination').should('exist')
 })
 
 Then('I should not see pagination previous link', () => {
-  cy.get('.govuk-pagination__prev').should('not.exist')
+  cy.get('.moj-pagination__item--prev').should('not.exist')
 })
 
 Then('I should not see pagination next link', () => {
-  cy.get('.govuk-pagination__next').should('not.exist')
+  cy.get('.moj-pagination__item--next').should('not.exist')
 })
 
 Then('I should see pagination page {string} highlighted', $string => {
-  cy.get('.govuk-pagination__item--current').contains($string).should('exist')
+  cy.get('.moj-pagination__item--active').contains($string).should('exist')
 })
 
 Then('I should see pagination link {string} with href {string}', ($string, $href) => {
-  cy.get('.govuk-pagination__link').contains($string).should('exist').should('have.attr', 'href').and('include', $href)
+  cy.get('.moj-pagination__link').contains($string).should('exist').should('have.attr', 'href').and('include', $href)
 })
 
 Then('I should see pagination next link with href {string}', ($href) => {
-  cy.get('.govuk-pagination__next').within(() => {
-    cy.get('.govuk-pagination__link').should('have.attr', 'href').and('include', $href)
+  cy.get('.moj-pagination__item--next').within(() => {
+    cy.get('.moj-pagination__link').should('have.attr', 'href').and('include', $href)
  })
 })
 
 Then('I should see pagination previous link with href {string}', ($href) => {
-  cy.get('.govuk-pagination__prev').within(() => {
-    cy.get('.govuk-pagination__link').should('have.attr', 'href').and('include', $href)
+  cy.get('.moj-pagination__item--prev').within(() => {
+    cy.get('.moj-pagination__link').should('have.attr', 'href').and('include', $href)
  })
 })
 
 Then('I should not see pagination', () => {
-  cy.get('.govuk-pagination').should('not.exist')
+  cy.get('.moj-pagination').should('not.exist')
 })
 
 Then('I click pagination link {string}', $string => {
-  cy.get('.govuk-pagination__link').contains($string).click()
+  cy.get('.moj-pagination__link').contains($string).click()
 })
 
 Then('I should see an ellipsis on the pagination', () => {
-  cy.get('.govuk-pagination__item--ellipses').should('exist')
+  cy.get('.moj-pagination__item--dots').should('exist')
 })
 
 Then('I should not see an ellipsis on the pagination', () => {
-  cy.get('.govuk-pagination__item--ellipses').should('not.exist')
+  cy.get('.moj-pagination__item--dots').should('not.exist')
 })
 
 Then('I click pagination next link', () => {
-  cy.get('.govuk-pagination__next').click()
+  cy.get('.moj-pagination__item--next').click()
 })
 
 Then('I click pagination previous link', () => {
-  cy.get('.govuk-pagination__prev').click()
+  cy.get('.moj-pagination__item--prev').click()
 })

--- a/integration-tests/cypress/support/step_definitions/common.js
+++ b/integration-tests/cypress/support/step_definitions/common.js
@@ -639,3 +639,7 @@ Then('I click pagination next link', () => {
 Then('I click pagination previous link', () => {
   cy.get('.moj-pagination__item--prev').click()
 })
+
+Then('I should see pagination text {string}', $string => {
+  cy.get('.moj-pagination__results').contains($string)
+})

--- a/server/routes/handlers/getPagedCaseListRouteHandler.js
+++ b/server/routes/handlers/getPagedCaseListRouteHandler.js
@@ -101,7 +101,7 @@ const getPaginationObject = (pageParams) => {
   pagination.pageItems.forEach(x => {
     recentlyAddedPageItems.push({
       ...x,
-      href: '/' + pageParams.courtCode + '/cases/' + pageParams.date + '/' + pageParams.subsection + '?page=' + x.number
+      href: '/' + pageParams.courtCode + '/cases/' + pageParams.date + '/' + pageParams.subsection + '?page=' + x.text
     })
   })
 

--- a/server/routes/handlers/matchRecords/matchingRecordRouteHandler.js
+++ b/server/routes/handlers/matchRecords/matchingRecordRouteHandler.js
@@ -60,7 +60,9 @@ const matchingRecordRouteHandler = (getMatchDetails, getCaseAndTemplateValues) =
     pagination: {
       ...getPagination(currentPage, matchingRecordsCount, recordsPerPage, baseUrl),
       totalPages,
-      matchingRecordsCount
+      matchingRecordsCount,
+      from: start,
+      to: end
     },
     backUrl: getBackUrl(session, hearingId, defendantId)
   }

--- a/server/utils/pagination.js
+++ b/server/utils/pagination.js
@@ -4,20 +4,20 @@ const getPagination = (currentPage, resultsCount, resultsPerPageLimit, baseUrl) 
 
   const pageItems = []
 
-  const addPageNumber = ({ number, current, ellipsis }) => {
+  const addPageNumber = ({ number, selected, type }) => {
     pageItems.push({
-      number,
+      text: number,
       href: baseUrl + 'page=' + number,
-      current,
-      ellipsis
+      selected,
+      type
     })
   }
 
   const pageSet = new Set([firstPage, firstPage + 1, currentPage - 1, currentPage, currentPage + 1, totalPages - 1, totalPages]
     .filter(x => x >= firstPage && x <= totalPages))
   pageSet.forEach(i => {
-    const ellipsis = (i > firstPage && i < currentPage - 2) || (i < totalPages && i > currentPage + 2)
-    addPageNumber({ number: i, current: currentPage === i, ellipsis })
+    const type = (i > firstPage && i < currentPage - 2) || (i < totalPages && i > currentPage + 2) ? 'dots' : null
+    addPageNumber({ number: i, selected: currentPage === i, type })
   })
 
   const previousLink = currentPage > firstPage

--- a/server/views/case-list.njk
+++ b/server/views/case-list.njk
@@ -113,8 +113,13 @@
             {% if pagination.totalPages > 1 %}
                 {%- set showSubsectionLinks = (params.subsection === 'added' or params.subsection === 'heard') -%}
                 {% block paginationBlock %}
-                    {% from "govuk/components/pagination/macro.njk" import govukPagination %}
-                    {{ govukPagination({
+                    {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
+                    {{ mojPagination({
+                        results: {
+                            from: params.from + 1,
+                            to: params.to,
+                            count: params.caseCount
+                        },
                         previous: pagination.recentlyAddedPreviousLink if showSubsectionLinks else pagination.previousLink,
                         next: pagination.recentlyAddedNextLink if showSubsectionLinks else pagination.nextLink,
                         items: pagination.recentlyAddedPageItems if showSubsectionLinks else pagination.pageItems

--- a/server/views/case-search.njk
+++ b/server/views/case-search.njk
@@ -72,9 +72,16 @@
                     {{ govukTable(tableData) }}
             {% endblock %}
 
+            {% set toElementCount = (currentPage * pageSize) if (currentPage * pageSize) <= data.totalElements else data.totalElements %}
+
             {% block pagination %}
-                {% from "govuk/components/pagination/macro.njk" import govukPagination %}
-                {{ govukPagination({
+                {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
+                {{ mojPagination({
+                    results: {
+                        from: (currentPage - 1) * pageSize + 1,
+                        to: toElementCount,
+                        count: data.totalElements
+                    },
                     previous: pagination.previousLink,
                     next: pagination.nextLink,
                     items: pagination.pageItems

--- a/server/views/match-defendant.njk
+++ b/server/views/match-defendant.njk
@@ -207,18 +207,22 @@
         </div>
 
       </div>
-    </div>
-
     {% if data.pagination.totalPages > 1 %}
       {% block paginationBlock %}
-        {% from "govuk/components/pagination/macro.njk" import govukPagination %}
-        {{ govukPagination({
-          previous: data.pagination.previousLink,
-          next: data.pagination.nextLink,
-          items: data.pagination.pageItems
+        {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
+        {{ mojPagination({
+          results: {
+            from: data.pagination.from + 1,
+            to: data.pagination.to,
+            count: data.pagination.matchingRecordsCount
+            },
+            previous: data.pagination.previousLink,
+            next: data.pagination.nextLink,
+            items: data.pagination.pageItems
         }) }}
       {% endblock %}
     {% endif %}
+    </div>
 
     {% from "govuk/components/details/macro.njk" import govukDetails %}
     {%- set detailsText = "<p class=\"govuk-body\">If the defendant is unknown to probation, you must <a href=\"/" + params.courtCode + "/case/" + params.caseId + "/hearing/" + params.hearingId + "/match/defendant/" + params.defendantId + "/nomatch\" class=\"govuk-link govuk-link--no-visited-state\">confirm they have no record</a>.</p><p class=\"govuk-body\">If they have an NDelius record, you can <a href=\"/" + params.courtCode + "/case/" + params.caseId + "/hearing/" + params.hearingId + "/match/defendant/" + params.defendantId + "/manual\" class=\"govuk-link govuk-link--no-visited-state\">link it to them with a case reference number</a>.</p>" -%}

--- a/server/views/outcomes/outcomes-paging-partial.njk
+++ b/server/views/outcomes/outcomes-paging-partial.njk
@@ -1,7 +1,15 @@
 {% if totalPages > 1 %}
+
+    {% set toElementCount = (params.currentPage * params.pageSize) if (params.currentPage * params.pageSize) <= totalElements else totalElements %}
+
     {% block pagination %}
-        {% from "govuk/components/pagination/macro.njk" import govukPagination %}
-        {{ govukPagination({
+        {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
+        {{ mojPagination({
+            results: {
+                from: (params.currentPage - 1) * params.pageSize + 1,
+                to: toElementCount,
+                count: totalElements
+            },
             previous: pagination.previousLink,
             next: pagination.nextLink,
             items: pagination.pageItems

--- a/tests/routes/handlers/caseSearchHandler.test.js
+++ b/tests/routes/handlers/caseSearchHandler.test.js
@@ -33,10 +33,10 @@ describe('caseSearchHandler', () => {
       pagination: {
         pageItems: [
           {
-            current: true,
-            ellipsis: false,
+            selected: true,
+            type: null,
             href: '/case-search?term=C123456&page=1',
-            number: 1
+            text: 1
           }
         ],
         previousLink: null,

--- a/tests/routes/handlers/getPagedCaseListRouteHandler.test.js
+++ b/tests/routes/handlers/getPagedCaseListRouteHandler.test.js
@@ -147,8 +147,8 @@ describe('getPagedCaseListRouteHandler', () => {
         ],
         pagination: {
           totalPages: 1,
-          pageItems: [{ number: 1, href: '/ABC/cases/2020-11-11?someFilter=someFilterValue&page=1', current: true, ellipsis: false }],
-          recentlyAddedPageItems: [{ number: 1, href: '/ABC/cases/2020-11-11/?page=1', current: true, ellipsis: false }],
+          pageItems: [{ text: 1, href: '/ABC/cases/2020-11-11?someFilter=someFilterValue&page=1', selected: true, type: null }],
+          recentlyAddedPageItems: [{ text: 1, href: '/ABC/cases/2020-11-11/?page=1', selected: true, type: null }],
           previousLink: null,
           recentlyAddedPreviousLink: null,
           nextLink: null,

--- a/tests/routes/handlers/matchRecords/matchingRecordRouteHandler.test.js
+++ b/tests/routes/handlers/matchRecords/matchingRecordRouteHandler.test.js
@@ -46,10 +46,10 @@ describe('getMatchingRecordRouteHandler', () => {
       previousLink: null,
       pageItems: [
         {
-          current: true,
-          ellipsis: false,
+          selected: true,
+          type: null,
           href: '/test-court/case/test-case-id/hearing/test-hearing-id/match/defendant/test-defendant-id?page=1',
-          number: 1
+          text: 1
         }
       ]
     }
@@ -70,7 +70,9 @@ describe('getMatchingRecordRouteHandler', () => {
         pagination: {
           ...paginationObject,
           matchingRecordsCount: 2,
-          totalPages: 1
+          totalPages: 1,
+          from: 0,
+          to: 2
         }
       }
     })


### PR DESCRIPTION
Changes PAC back to use MOJ Pagination rather than GDS pagination which was introduced in https://github.com/ministryofjustice/prepare-a-case/pull/1043/files and deployed to dev but not pre-prod or prod

We are changing it back to MOJ pagination so that the 'results' section can be retained