### PR TITLE
ensure pagination works across all tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:lint": "docker exec -it prepare-a-case-app /app/node_modules/.bin/standard",
     "test:lint:fix": "npm run test:lint -- --fix",
     "test:unit": "docker exec -it -e ENABLE_HEARING_OUTCOMES=false prepare-a-case-app /app/node_modules/.bin/jest --config=./tests/jest.config.js --detectOpenHandles --ci --forceExit",
+    "test:unit:watch": "docker exec -it -e ENABLE_HEARING_OUTCOMES=false prepare-a-case-app /app/node_modules/.bin/jest --config=./tests/jest.config.js --detectOpenHandles --watchAll",
     "test:pact": "docker exec -it prepare-a-case-app /app/node_modules/.bin/jest --config=./tests/jest.pact.config.js --detectOpenHandles --ci --forceExit",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config-file integration-tests/cypress/cypress.config.js video=false",

--- a/server/routes/handlers/getPagedCaseListRouteHandler.js
+++ b/server/routes/handlers/getPagedCaseListRouteHandler.js
@@ -19,8 +19,9 @@ const createBaseUrl = (params, queryParams) => {
   const questionMark = builtQueryParamString.length > 0
 
   const date = params.date ? params.date : getTodaysDate()
+  const subsection = params.subsection ? `/${params.subsection}` : ''
 
-  return `/${params.courtCode}/cases/${date}?${queryParamBuilder(remainder)}${questionMark ? '&' : ''}`
+  return `/${params.courtCode}/cases/${date}${subsection}?${builtQueryParamString}${questionMark ? '&' : ''}`
 }
 
 const getPagelessQueryParams = params => {
@@ -113,37 +114,11 @@ const getPageTabs = (params) => {
 const getPaginationObject = (pageParams) => {
   const currentPage = pageParams.page
   const pagination = getPagination(currentPage, pageParams.caseCount, pageParams.limit, pageParams.baseUrl)
-
-  const recentlyAddedPageItems = []
-  pagination.pageItems.forEach(x => {
-    recentlyAddedPageItems.push({
-      ...x,
-      href: '/' + pageParams.courtCode + '/cases/' + pageParams.date + '/' + pageParams.subsection + '?page=' + x.text
-    })
-  })
-
-  const recentlyAddedPreviousLink = pagination.previousLink !== null
-    ? {
-        ...pagination.previousLink,
-        href: '/' + pageParams.courtCode + '/cases/' + pageParams.date + '/' + pageParams.subsection + '?page=' + (currentPage - 1)
-      }
-    : null
-
-  const recentlyAddedNextLink = pagination.nextLink !== null
-    ? {
-        ...pagination.nextLink,
-        href: '/' + pageParams.courtCode + '/cases/' + pageParams.date + '/' + pageParams.subsection + '?page=' + (currentPage + 1)
-      }
-    : null
-
   const totalPages = Math.round(Math.ceil((pageParams.caseCount / pageParams.limit)))
 
   return {
     ...pagination,
-    totalPages,
-    recentlyAddedPageItems,
-    recentlyAddedPreviousLink,
-    recentlyAddedNextLink
+    totalPages
   }
 }
 
@@ -219,6 +194,8 @@ const getPagedCaseListRouteHandler = (caseService, userPreferenceService) => asy
       })
   }
 
+  const resolvedSubsection = subsection || (!date && session.currentView) || ''
+
   const pageParams = {
     ...params,
     workflow: {
@@ -243,9 +220,9 @@ const getPagedCaseListRouteHandler = (caseService, userPreferenceService) => asy
     totalDays: pastCaseNavigationEnabled ? settings.casesTotalDays : 7,
     casesPastDays: pastCaseNavigationEnabled ? settings.casesPastDays : -1,
     enablePastCasesNavigation: settings.enablePastCasesNavigation,
-    subsection: subsection || (!date && session.currentView) || '',
+    subsection: resolvedSubsection,
     filtersApplied: !!getPagelessQueryParams(queryParams) && Object.keys(getPagelessQueryParams(queryParams)).length > 0,
-    baseUrl: createBaseUrl({ courtCode, date }, queryParams)
+    baseUrl: createBaseUrl({ courtCode, date, subsection: resolvedSubsection }, queryParams)
   }
 
   let templateValues = {

--- a/server/views/case-list.njk
+++ b/server/views/case-list.njk
@@ -131,7 +131,6 @@
             {% endif %}
 
             {% if pagination.totalPages > 1 %}
-                {%- set showSubsectionLinks = (params.subsection === 'added' or params.subsection === 'heard') -%}
                 {% block paginationBlock %}
                     {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
                     {{ mojPagination({
@@ -140,9 +139,9 @@
                             to: params.to,
                             count: params.caseCount
                         },
-                        previous: pagination.recentlyAddedPreviousLink if showSubsectionLinks else pagination.previousLink,
-                        next: pagination.recentlyAddedNextLink if showSubsectionLinks else pagination.nextLink,
-                        items: pagination.recentlyAddedPageItems if showSubsectionLinks else pagination.pageItems
+                        previous: pagination.previousLink,
+                        next: pagination.nextLink,
+                        items: pagination.pageItems
                     }) }}
                 {% endblock %}
             {% endif %}

--- a/tests/routes/handlers/getPagedCaseListRouteHandler.test.js
+++ b/tests/routes/handlers/getPagedCaseListRouteHandler.test.js
@@ -215,92 +215,148 @@ describe('getPagedCaseListRouteHandler', () => {
     })
   })
 
-  it('should add query params to subsection base url (except page)', async () => {
-  // Given
-    const mockRequest = createMockRequest({
-      params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection: 'outcome-not-required' },
-      query: { page: 1, someFilter: 'someFilterValue' },
-      path: '/ABC/cases/2020-11-11/outcome-not-required'
-    })
+  describe('subsection pagination', () => {
+    const subsectionTabs = ['added', 'heard', 'removed', 'outcome-not-required']
 
-    caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
-
-    jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
-    jest.replaceProperty(settings, 'pacEnvironment', 'dev')
-
-    // When
-    await subject(mockRequest, mockResponse)
-
-    // Then
-    expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
-      params: {
-        baseUrl: '/ABC/cases/2020-11-11/outcome-not-required?someFilter=someFilterValue&'
-      }
-    })
-  })
-
-  it('should include subsection in baseUrl for hearing outcome not required tab', async () => {
-    // Given
-    const mockRequest = createMockRequest({
-      params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection: 'outcome-not-required' },
-      query: { page: 1 },
-      path: '/ABC/cases/2020-11-11/outcome-not-required'
-    })
-
-    caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
-
-    jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
-    jest.replaceProperty(settings, 'pacEnvironment', 'dev')
-
-    // When
-    await subject(mockRequest, mockResponse)
-
-    // Then
-    expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
-      params: {
-        subsection: 'outcome-not-required',
-        baseUrl: '/ABC/cases/2020-11-11/outcome-not-required?'
-      }
-    })
-  })
-
-  it('should generate pagination links with subsection for hearing outcome not required tab', async () => {
-    // Given
-    const mockRequest = createMockRequest({
-      params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection: 'outcome-not-required' },
-      query: { page: 1 },
-      path: '/ABC/cases/2020-11-11/outcome-not-required'
-    })
-
-    caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
-
-    jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
-    jest.replaceProperty(settings, 'pacEnvironment', 'dev')
-
-    // When
-    await subject(mockRequest, mockResponse)
-
-    // Then
-    const renderArgs = mockResponse.render.mock.calls[0][1]
-
-    expect(renderArgs.pagination.nextLink).toMatchObject({
-      text: 'Next',
-      href: '/ABC/cases/2020-11-11/outcome-not-required?page=2'
-    })
-
-    expect(renderArgs.pagination.pageItems).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          text: 1,
-          href: '/ABC/cases/2020-11-11/outcome-not-required?page=1',
-          selected: true
-        }),
-        expect.objectContaining({
-          text: 2,
-          href: '/ABC/cases/2020-11-11/outcome-not-required?page=2',
-          selected: false
+    it.each(subsectionTabs)(
+      'should include subsection in baseUrl for %s tab',
+      async (subsection) => {
+      // Given
+        const mockRequest = createMockRequest({
+          params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection },
+          query: { page: 1 },
+          path: `/ABC/cases/2020-11-11/${subsection}`
         })
-      ])
+
+        caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
+
+        jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
+        jest.replaceProperty(settings, 'pacEnvironment', 'dev')
+
+        // When
+        await subject(mockRequest, mockResponse)
+
+        // Then
+        expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
+          params: {
+            subsection,
+            baseUrl: `/ABC/cases/2020-11-11/${subsection}?`
+          }
+        })
+      }
+    )
+
+    it.each(subsectionTabs)(
+      'should add query params to subsection base url (except page) for %s tab',
+      async (subsection) => {
+      // Given
+        const mockRequest = createMockRequest({
+          params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection },
+          query: { page: 1, someFilter: 'someFilterValue' },
+          path: `/ABC/cases/2020-11-11/${subsection}`
+        })
+
+        caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
+
+        jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
+        jest.replaceProperty(settings, 'pacEnvironment', 'dev')
+
+        // When
+        await subject(mockRequest, mockResponse)
+
+        // Then
+        expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
+          params: {
+            baseUrl: `/ABC/cases/2020-11-11/${subsection}?someFilter=someFilterValue&`
+          }
+        })
+      }
+    )
+
+    it.each(subsectionTabs)(
+      'should generate pagination links with subsection for %s tab',
+      async (subsection) => {
+      // Given
+        const mockRequest = createMockRequest({
+          params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection },
+          query: { page: 1 },
+          path: `/ABC/cases/2020-11-11/${subsection}`
+        })
+
+        caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
+
+        jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
+        jest.replaceProperty(settings, 'pacEnvironment', 'dev')
+
+        // When
+        await subject(mockRequest, mockResponse)
+
+        // Then
+        const renderArgs = mockResponse.render.mock.calls[0][1]
+
+        expect(renderArgs.pagination.nextLink).toMatchObject({
+          text: 'Next',
+          href: `/ABC/cases/2020-11-11/${subsection}?page=2`
+        })
+
+        expect(renderArgs.pagination.pageItems).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              text: 1,
+              href: `/ABC/cases/2020-11-11/${subsection}?page=1`,
+              selected: true
+            }),
+            expect.objectContaining({
+              text: 2,
+              href: `/ABC/cases/2020-11-11/${subsection}?page=2`,
+              selected: false
+            })
+          ])
+        )
+      }
+    )
+
+    it.each(subsectionTabs)(
+      'should preserve subsection and query params in pagination links for %s tab',
+      async (subsection) => {
+      // Given
+        const mockRequest = createMockRequest({
+          params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection },
+          query: { page: 1, someFilter: 'someFilterValue' },
+          path: `/ABC/cases/2020-11-11/${subsection}`
+        })
+
+        caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
+
+        jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
+        jest.replaceProperty(settings, 'pacEnvironment', 'dev')
+
+        // When
+        await subject(mockRequest, mockResponse)
+
+        // Then
+        const renderArgs = mockResponse.render.mock.calls[0][1]
+
+        expect(renderArgs.pagination.nextLink).toMatchObject({
+          text: 'Next',
+          href: `/ABC/cases/2020-11-11/${subsection}?someFilter=someFilterValue&page=2`
+        })
+
+        expect(renderArgs.pagination.pageItems).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              text: 1,
+              href: `/ABC/cases/2020-11-11/${subsection}?someFilter=someFilterValue&page=1`,
+              selected: true
+            }),
+            expect.objectContaining({
+              text: 2,
+              href: `/ABC/cases/2020-11-11/${subsection}?someFilter=someFilterValue&page=2`,
+              selected: false
+            })
+          ])
+        )
+      }
     )
   })
 })

--- a/tests/routes/handlers/getPagedCaseListRouteHandler.test.js
+++ b/tests/routes/handlers/getPagedCaseListRouteHandler.test.js
@@ -10,23 +10,12 @@ jest.mock('../../../server/utils/nunjucksComponents', () => {
 })
 
 describe('getPagedCaseListRouteHandler', () => {
-  beforeEach(() => {
-    jest.replaceProperty(settings, 'casesTotalDays', 13)
-    jest.replaceProperty(settings, 'casesPastDays', 6)
-    jest.replaceProperty(settings, 'enableWorkflow', true)
-  })
-
   const { caseServiceMock: caseService, mockResponse } = require('./test-helpers')
-  const userPreferenceService = { getFilters: jest.fn().mockResolvedValue({}), setFilters: jest.fn().mockResolvedValue() }
-  const subject = require('../../../server/routes/handlers/getPagedCaseListRouteHandler')(caseService, userPreferenceService)
-  const mockRequest = {
-    redisClient: { getAsync: jest.fn().mockResolvedValue(null) },
-    params: { courtCode: 'ABC', date: '2020-11-11', limit: 10 },
-    query: { page: 1 },
-    session: {},
-    path: '/SHF/cases',
-    flash: jest.fn().mockReturnValue([])
+  const userPreferenceService = {
+    getFilters: jest.fn().mockResolvedValue({}),
+    setFilters: jest.fn().mockResolvedValue()
   }
+  const subject = require('../../../server/routes/handlers/getPagedCaseListRouteHandler')(caseService, userPreferenceService)
 
   const mockCase = () => ({
     courtRoom: 'Some courtroom',
@@ -66,113 +55,133 @@ describe('getPagedCaseListRouteHandler', () => {
     }
   }
 
+  const createMockRequest = (overrides = {}) => ({
+    redisClient: { getAsync: jest.fn().mockResolvedValue(null) },
+    params: { courtCode: 'ABC', date: '2020-11-11', limit: 10 },
+    query: { page: 1 },
+    session: {},
+    path: '/SHF/cases',
+    flash: jest.fn().mockReturnValue([]),
+    ...overrides
+  })
+
+  const standardCaseListResponse = (overrides = {}) => ({
+    possibleMatchesCount: 2,
+    recentlyAddedCount: 2,
+    removedCount: undefined,
+    filters: [{ label: 'Probation status' }, { label: 'Courtroom' }, { label: 'Session' }],
+    cases: [mockCase(), mockCase(), mockCase(), mockCase()],
+    totalElements: 4,
+    ...overrides
+  })
+
+  const paginatedCaseListResponse = (overrides = {}) => ({
+    possibleMatchesCount: 0,
+    recentlyAddedCount: 0,
+    removedCount: 0,
+    filters: [],
+    cases: Array.from({ length: 20 }, () => mockCase()),
+    totalElements: 40,
+    ...overrides
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.replaceProperty(settings, 'casesTotalDays', 13)
+    jest.replaceProperty(settings, 'casesPastDays', 6)
+    jest.replaceProperty(settings, 'enableWorkflow', true)
+  })
+
   it('should render error page when getPagedCaseList returns errors', async () => {
     // Given
+    const mockRequest = createMockRequest({
+      query: { page: 1, someFilter: 'someFilterValue' }
+    })
     caseService.getPagedCaseList.mockReturnValueOnce({ isError: true, status: 500 })
-
-    mockRequest.query = { ...mockRequest.query, someFilter: 'someFilterValue' }
 
     // When
     await subject(mockRequest, mockResponse)
 
     // Then
     expect(mockRequest.redisClient.getAsync).toHaveBeenCalledWith('case-list-notification')
-    expect(caseService.getPagedCaseList).toHaveBeenCalled()
     expect(caseService.getPagedCaseList).toHaveBeenCalledWith('ABC', '2020-11-11', { someFilter: 'someFilterValue' }, false, 1, 20, expect.any(Boolean))
-    expect(mockResponse.render).toHaveBeenCalled()
     expect(mockResponse.render).toHaveBeenCalledWith('error', { status: 500 })
   })
 
   it('should successfully render case list returned by getPagedCaseList', async () => {
     // Given
-    caseService.getPagedCaseList.mockReturnValueOnce({
-      possibleMatchesCount: 2,
-      recentlyAddedCount: 2,
-      filters: [{ label: 'Probation status' }, { label: 'Courtroom' }, { label: 'Session' }],
-      cases: [mockCase(), mockCase(), mockCase(), mockCase()],
-      totalElements: 4
+    const mockRequest = createMockRequest({
+      query: { page: 1, someFilter: 'someFilterValue' }
     })
+
+    caseService.getPagedCaseList.mockReturnValueOnce(standardCaseListResponse())
 
     jest.replaceProperty(settings, 'enablePastCasesNavigation', true)
     jest.replaceProperty(settings, 'pacEnvironment', 'dev')
 
     // When
-    mockRequest.query = { ...mockRequest.query, someFilter: 'someFilterValue' }
     await subject(mockRequest, mockResponse)
 
     // Then
-    expect(mockRequest.redisClient.getAsync).toHaveBeenCalledWith('case-list-notification')
-    expect(caseService.getPagedCaseList).toHaveBeenCalled()
-    expect(caseService.getPagedCaseList).toHaveBeenCalledWith('ABC', '2020-11-11', { someFilter: 'someFilterValue' }, false, 1, 20, expect.any(Boolean))
-    expect(mockResponse.render).toHaveBeenCalled()
-    expect(mockResponse.render).toHaveBeenCalledWith('case-list',
-      {
-        title: 'Case list',
-        data: [mockCaseResult(), mockCaseResult(), mockCaseResult(), mockCaseResult()],
-        params: {
-          hearingOutcomesEnabled: expect.any(Boolean),
-          workflow,
-          addedCount: 2,
-          removedCount: undefined,
-          caseCount: 4,
-          courtCode: 'ABC',
-          date: '2020-11-11',
-          filters: [{ label: 'Probation status' }, { label: 'Courtroom' }, { label: 'Session' }],
-          filtersApplied: true,
-          from: 0,
-          limit: 10,
-          notification: '',
-          page: 1,
-          subsection: '',
-          to: 4,
-          totalDays: 13,
-          casesPastDays: 6,
-          unmatchedRecords: 2,
-          enablePastCasesNavigation: true,
-          baseUrl: '/ABC/cases/2020-11-11?someFilter=someFilterValue&'
-        },
-        listTabs: expect.any(Array),
-        pagination: {
-          totalPages: 1,
-          pageItems: [{ text: 1, href: '/ABC/cases/2020-11-11?someFilter=someFilterValue&page=1', selected: true, type: null }],
-          recentlyAddedPageItems: [{ text: 1, href: '/ABC/cases/2020-11-11/?page=1', selected: true, type: null }],
-          previousLink: null,
-          recentlyAddedPreviousLink: null,
-          nextLink: null,
-          recentlyAddedNextLink: null
-        },
-        tableData: expect.objectContaining({
-          head: expect.any(Array),
-          rows: expect.any(Array)
-        }),
+    expect(mockResponse.render).toHaveBeenCalledWith('case-list', expect.anything())
+
+    expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
+      title: 'Case list',
+      data: [mockCaseResult(), mockCaseResult(), mockCaseResult(), mockCaseResult()],
+      params: {
         hearingOutcomesEnabled: expect.any(Boolean),
-        toggleOutcomeSuccessMessage: [],
-        globalError: []
-      })
+        workflow,
+        addedCount: 2,
+        removedCount: undefined,
+        caseCount: 4,
+        courtCode: 'ABC',
+        date: '2020-11-11',
+        filters: [{ label: 'Probation status' }, { label: 'Courtroom' }, { label: 'Session' }],
+        filtersApplied: true,
+        from: 0,
+        limit: 10,
+        notification: '',
+        page: 1,
+        subsection: '',
+        to: 4,
+        totalDays: 13,
+        casesPastDays: 6,
+        unmatchedRecords: 2,
+        enablePastCasesNavigation: true,
+        baseUrl: '/ABC/cases/2020-11-11?someFilter=someFilterValue&'
+      },
+      listTabs: expect.any(Array),
+      pagination: {
+        totalPages: 1,
+        pageItems: [{ text: 1, href: '/ABC/cases/2020-11-11?someFilter=someFilterValue&page=1', selected: true, type: null }]
+      },
+      tableData: expect.objectContaining({
+        head: expect.any(Array),
+        rows: expect.any(Array)
+      }),
+      hearingOutcomesEnabled: expect.any(Boolean),
+      toggleOutcomeSuccessMessage: [],
+      globalError: []
+    })
   })
 
   it('should disable past days navigation if enablePastCasesNavigation is not true', async () => {
     // Given
-    caseService.getPagedCaseList.mockReturnValueOnce({
-      possibleMatchesCount: 2,
-      recentlyAddedCount: 2,
-      filters: [{ label: 'Probation status' }, { label: 'Courtroom' }, { label: 'Session' }],
-      cases: [mockCase(), mockCase(), mockCase(), mockCase()],
-      totalElements: 4
+    const mockRequest = createMockRequest({
+      query: { page: 1, someFilter: 'someFilterValue' }
     })
+
+    caseService.getPagedCaseList.mockReturnValueOnce(standardCaseListResponse())
 
     jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
     jest.replaceProperty(settings, 'pacEnvironment', 'dev')
 
     // When
-    mockRequest.query = { ...mockRequest.query, someFilter: 'someFilterValue' }
     await subject(mockRequest, mockResponse)
 
     // Then
     expect(mockRequest.redisClient.getAsync).toHaveBeenCalledWith('case-list-notification')
-    expect(caseService.getPagedCaseList).toHaveBeenCalled()
     expect(caseService.getPagedCaseList).toHaveBeenCalledWith('ABC', '2020-11-11', { someFilter: 'someFilterValue' }, false, 1, 20, expect.any(Boolean))
-    expect(mockResponse.render).toHaveBeenCalled()
 
     expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
       params: {
@@ -183,32 +192,115 @@ describe('getPagedCaseListRouteHandler', () => {
 
   it('should add query params to base url (except page)', async () => {
     // Given
-    caseService.getPagedCaseList.mockReturnValueOnce({
-      possibleMatchesCount: 2,
-      recentlyAddedCount: 2,
-      filters: [{ label: 'Probation status' }, { label: 'Courtroom' }, { label: 'Session' }],
-      cases: [mockCase(), mockCase(), mockCase(), mockCase()],
-      totalElements: 4
+    const mockRequest = createMockRequest({
+      query: { page: 1, someFilter: 'someFilterValue' }
     })
+
+    caseService.getPagedCaseList.mockReturnValueOnce(standardCaseListResponse())
 
     jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
     jest.replaceProperty(settings, 'pacEnvironment', 'dev')
 
     // When
-    mockRequest.query = { ...mockRequest.query, someFilter: 'someFilterValue' }
     await subject(mockRequest, mockResponse)
 
     // Then
     expect(mockRequest.redisClient.getAsync).toHaveBeenCalledWith('case-list-notification')
-    expect(caseService.getPagedCaseList).toHaveBeenCalled()
     expect(caseService.getPagedCaseList).toHaveBeenCalledWith('ABC', '2020-11-11', { someFilter: 'someFilterValue' }, false, 1, 20, expect.any(Boolean))
-    expect(mockResponse.render).toHaveBeenCalled()
-    expect(mockResponse.render).toHaveBeenCalledWith('case-list', expect.anything())
 
     expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
       params: {
         baseUrl: '/ABC/cases/2020-11-11?someFilter=someFilterValue&'
       }
     })
+  })
+
+  it('should add query params to subsection base url (except page)', async () => {
+  // Given
+  const mockRequest = createMockRequest({
+    params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection: 'outcome-not-required' },
+    query: { page: 1, someFilter: 'someFilterValue' },
+    path: '/ABC/cases/2020-11-11/outcome-not-required'
+  })
+
+  caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
+
+  jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
+  jest.replaceProperty(settings, 'pacEnvironment', 'dev')
+
+  // When
+  await subject(mockRequest, mockResponse)
+
+  // Then
+  expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
+    params: {
+      baseUrl: '/ABC/cases/2020-11-11/outcome-not-required?someFilter=someFilterValue&'
+    }
+  })
+})
+
+  it('should include subsection in baseUrl for hearing outcome not required tab', async () => {
+    // Given
+    const mockRequest = createMockRequest({
+      params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection: 'outcome-not-required' },
+      query: { page: 1 },
+      path: '/ABC/cases/2020-11-11/outcome-not-required'
+    })
+
+    caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
+
+    jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
+    jest.replaceProperty(settings, 'pacEnvironment', 'dev')
+
+    // When
+    await subject(mockRequest, mockResponse)
+
+    // Then
+    expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
+      params: {
+        subsection: 'outcome-not-required',
+        baseUrl: '/ABC/cases/2020-11-11/outcome-not-required?'
+      }
+    })
+  })
+
+  it('should generate pagination links with subsection for hearing outcome not required tab', async () => {
+    // Given
+    const mockRequest = createMockRequest({
+      params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection: 'outcome-not-required' },
+      query: { page: 1 },
+      path: '/ABC/cases/2020-11-11/outcome-not-required'
+    })
+
+    caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
+
+    jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
+    jest.replaceProperty(settings, 'pacEnvironment', 'dev')
+
+    // When
+    await subject(mockRequest, mockResponse)
+
+    // Then
+    const renderArgs = mockResponse.render.mock.calls[0][1]
+
+    expect(renderArgs.pagination.nextLink).toMatchObject({
+      text: 'Next',
+      href: '/ABC/cases/2020-11-11/outcome-not-required?page=2'
+    })
+
+    expect(renderArgs.pagination.pageItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: 1,
+          href: '/ABC/cases/2020-11-11/outcome-not-required?page=1',
+          selected: true
+        }),
+        expect.objectContaining({
+          text: 2,
+          href: '/ABC/cases/2020-11-11/outcome-not-required?page=2',
+          selected: false
+        })
+      ])
+    )
   })
 })

--- a/tests/routes/handlers/getPagedCaseListRouteHandler.test.js
+++ b/tests/routes/handlers/getPagedCaseListRouteHandler.test.js
@@ -217,27 +217,27 @@ describe('getPagedCaseListRouteHandler', () => {
 
   it('should add query params to subsection base url (except page)', async () => {
   // Given
-  const mockRequest = createMockRequest({
-    params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection: 'outcome-not-required' },
-    query: { page: 1, someFilter: 'someFilterValue' },
-    path: '/ABC/cases/2020-11-11/outcome-not-required'
+    const mockRequest = createMockRequest({
+      params: { courtCode: 'ABC', date: '2020-11-11', limit: 10, subsection: 'outcome-not-required' },
+      query: { page: 1, someFilter: 'someFilterValue' },
+      path: '/ABC/cases/2020-11-11/outcome-not-required'
+    })
+
+    caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
+
+    jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
+    jest.replaceProperty(settings, 'pacEnvironment', 'dev')
+
+    // When
+    await subject(mockRequest, mockResponse)
+
+    // Then
+    expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
+      params: {
+        baseUrl: '/ABC/cases/2020-11-11/outcome-not-required?someFilter=someFilterValue&'
+      }
+    })
   })
-
-  caseService.getPagedCaseList.mockReturnValueOnce(paginatedCaseListResponse())
-
-  jest.replaceProperty(settings, 'enablePastCasesNavigation', false)
-  jest.replaceProperty(settings, 'pacEnvironment', 'dev')
-
-  // When
-  await subject(mockRequest, mockResponse)
-
-  // Then
-  expect(mockResponse.render.mock.calls[0][1]).toMatchObject({
-    params: {
-      baseUrl: '/ABC/cases/2020-11-11/outcome-not-required?someFilter=someFilterValue&'
-    }
-  })
-})
 
   it('should include subsection in baseUrl for hearing outcome not required tab', async () => {
     // Given


### PR DESCRIPTION
Pagination was not working on **Hearing outcome not required** or **Removed cases** tabs because it did not take into account the subsection when creating the pagination links

Resolved by passing the subsection when creating the base URL, allowing pagination logic to be tidied up

Added tests around this and refactored the test file to prevent test pollution