### PR TITLE
fix autosave bug for comments and notes

### DIFF
--- a/public/src/javascripts/case-progress.js
+++ b/public/src/javascripts/case-progress.js
@@ -12,13 +12,13 @@
     return cookie[name];
   }
 
-  function getAutoSaveHandler(textarea, url, inputDataFormatter) {
-    let timeoutId;
+  function getAutoSaveHandler(textarea, url, inputDataFormatter, timeoutId, xhr) {
     const noteEventListener = (event) => {
       // If a timer was already started, clear it.
       if (timeoutId) clearTimeout(timeoutId);
       // Set timer that will save comment when it fires.
       timeoutId = setTimeout(function () {
+        if (xhr) xhr.abort();
         // Make ajax call to save data.
         const xhr = new XMLHttpRequest()
         xhr.open('PUT', url, true)
@@ -41,15 +41,32 @@
     return noteEventListener
   }
 
+  let autoSaveNoteTimeoutId;
+  let autoSaveNoteXhr;
   const setupAutoSaveHearingNote = (textarea) => {
-    textarea.addEventListener('keyup', getAutoSaveHandler(textarea,  'summary/auto-save-new-note', (textarea, event) => ({ note: event.srcElement.value, hearingId: textarea.dataset.hearingid }) ))
+    textarea.addEventListener('keyup', getAutoSaveHandler(textarea, 'summary/auto-save-new-note', (textarea, event) => ({ note: event.srcElement.value, hearingId: textarea.dataset.hearingid }), autoSaveNoteTimeoutId, autoSaveNoteXhr))
   }
 
   document.querySelectorAll('.auto-save-text').forEach(setupAutoSaveHearingNote)
+  // Cancel any pending auto-save when the form is intentionally submitted
+  const hearingNoteForm = document.querySelector('.hearing-note-form');
+  hearingNoteForm?.addEventListener('submit', () => {
+    if (autoSaveNoteTimeoutId) clearTimeout(autoSaveNoteTimeoutId);
+    if (autoSaveNoteXhr) autoSaveNoteXhr.abort();
+  });
 
+  let autoSaveCommentTimeoutId;
+  let autoSaveCommentXhr;
   const caseCommentsTextArea = document.querySelector('#case-comment');
   caseCommentsTextArea?.addEventListener('keyup',
-    getAutoSaveHandler(caseCommentsTextArea,  'summary/comments/auto-save-new-comment', (textarea, event) => ({ comment: event.srcElement.value, caseId: textarea.dataset.caseid }) ))
+    getAutoSaveHandler(caseCommentsTextArea,  'summary/comments/auto-save-new-comment', (textarea, event) => ({ comment: event.srcElement.value, caseId: textarea.dataset.caseid }), autoSaveCommentTimeoutId, autoSaveCommentXhr ))
+  
+  // Cancel any pending auto-save when the form is intentionally submitted
+  const caseCommentForm = document.querySelector('#case-comment-form');
+  caseCommentForm?.addEventListener('submit', () => {
+    if (autoSaveCommentTimeoutId) clearTimeout(autoSaveCommentTimeoutId);
+    if (autoSaveCommentXhr) autoSaveCommentXhr.abort();
+  });
 
 
   // Edit note

--- a/public/src/javascripts/case-progress.js
+++ b/public/src/javascripts/case-progress.js
@@ -12,62 +12,53 @@
     return cookie[name];
   }
 
-  function getAutoSaveHandler(textarea, url, inputDataFormatter, timeoutId, xhr) {
-    const noteEventListener = (event) => {
-      // If a timer was already started, clear it.
-      if (timeoutId) clearTimeout(timeoutId);
-      // Set timer that will save comment when it fires.
-      timeoutId = setTimeout(function () {
-        if (xhr) xhr.abort();
-        // Make ajax call to save data.
-        const xhr = new XMLHttpRequest()
-        xhr.open('PUT', url, true)
-        xhr.setRequestHeader('Content-Type', 'application/json')
-        xhr.setRequestHeader('x-csrf-token', window.csrfToken)
-        xhr.onload = function () {
-          if (this.status < 200 || this.status >= 400) {
-            console.log("Error status", this.status)
-          }
-        }
-        xhr.send(
-          JSON.stringify(
-            {
-              ...inputDataFormatter(textarea, event)
-            },
-          )
-        )
-      }, debounceTimer);
+  function createAutoSave(url) {
+    let timeoutId;
+    let xhr;
+    return {
+      schedule(data) {
+        // If a timer was already started, clear it.
+        if (timeoutId) clearTimeout(timeoutId);
+        // Set timer that will save comment when it fires.
+        timeoutId = setTimeout(function () {
+          if (xhr) xhr.abort()
+          // Make ajax call to save data.
+          xhr = new XMLHttpRequest()
+          xhr.open('PUT', url, true)
+          xhr.setRequestHeader('Content-Type', 'application/json')
+          xhr.setRequestHeader('x-csrf-token', window.csrfToken)
+          xhr.onload = function () {
+            if (this.status < 200 || this.status >= 400) {
+              console.log("Error status", this.status)
+            }
+          };
+          xhr.send(JSON.stringify(data))
+        }, debounceTimer)
+      },
+      cancel() {
+        if (timeoutId) clearTimeout(timeoutId)
+        if (xhr) xhr.abort()
+      }
     }
-    return noteEventListener
   }
 
-  let autoSaveNoteTimeoutId;
-  let autoSaveNoteXhr;
+  const noteAutoSave = createAutoSave('summary/auto-save-new-note')
   const setupAutoSaveHearingNote = (textarea) => {
-    textarea.addEventListener('keyup', getAutoSaveHandler(textarea, 'summary/auto-save-new-note', (textarea, event) => ({ note: event.srcElement.value, hearingId: textarea.dataset.hearingid }), autoSaveNoteTimeoutId, autoSaveNoteXhr))
+    textarea.addEventListener('keyup', (event) => {
+      noteAutoSave.schedule({ note: event.srcElement.value, hearingId: textarea.dataset.hearingid })
+    })
   }
-
   document.querySelectorAll('.auto-save-text').forEach(setupAutoSaveHearingNote)
   // Cancel any pending auto-save when the form is intentionally submitted
-  const hearingNoteForm = document.querySelector('.hearing-note-form');
-  hearingNoteForm?.addEventListener('submit', () => {
-    if (autoSaveNoteTimeoutId) clearTimeout(autoSaveNoteTimeoutId);
-    if (autoSaveNoteXhr) autoSaveNoteXhr.abort();
-  });
+  document.querySelector('.hearing-note-form')?.addEventListener('submit', () => noteAutoSave.cancel())
 
-  let autoSaveCommentTimeoutId;
-  let autoSaveCommentXhr;
+  const commentAutoSave = createAutoSave('summary/comments/auto-save-new-comment')
   const caseCommentsTextArea = document.querySelector('#case-comment');
-  caseCommentsTextArea?.addEventListener('keyup',
-    getAutoSaveHandler(caseCommentsTextArea,  'summary/comments/auto-save-new-comment', (textarea, event) => ({ comment: event.srcElement.value, caseId: textarea.dataset.caseid }), autoSaveCommentTimeoutId, autoSaveCommentXhr ))
-  
+  caseCommentsTextArea?.addEventListener('keyup', (event) => {
+    commentAutoSave.schedule({ comment: event.srcElement.value, caseId: caseCommentsTextArea.dataset.caseid })
+  })
   // Cancel any pending auto-save when the form is intentionally submitted
-  const caseCommentForm = document.querySelector('#case-comment-form');
-  caseCommentForm?.addEventListener('submit', () => {
-    if (autoSaveCommentTimeoutId) clearTimeout(autoSaveCommentTimeoutId);
-    if (autoSaveCommentXhr) autoSaveCommentXhr.abort();
-  });
-
+  document.querySelector('#case-comment-form')?.addEventListener('submit', () => commentAutoSave.cancel())
 
   // Edit note
 

--- a/public/src/javascripts/case-progress.js
+++ b/public/src/javascripts/case-progress.js
@@ -50,7 +50,9 @@
   }
   document.querySelectorAll('.auto-save-text').forEach(setupAutoSaveHearingNote)
   // Cancel any pending auto-save when the form is intentionally submitted
-  document.querySelector('.hearing-note-form')?.addEventListener('submit', () => noteAutoSave.cancel())
+  document.querySelectorAll('.hearing-note-form').forEach(form => {
+    form.addEventListener('submit', () => noteAutoSave.cancel())
+  })
 
   const commentAutoSave = createAutoSave('summary/comments/auto-save-new-comment')
   const caseCommentsTextArea = document.querySelector('#case-comment');

--- a/server/routes/handlers/getAddCommentRequestHandler.js
+++ b/server/routes/handlers/getAddCommentRequestHandler.js
@@ -8,6 +8,9 @@ const getAddCaseCommentHandler = caseService => async (req, res) => {
   } else {
     await caseService.addCaseComment(caseId, defendantId, comment, res.locals.user.name)
 
+    // Delete any draft so a late-arriving auto-save doesn't re-populate the textarea
+    await caseService.deleteCaseCommentDraft(caseId, defendantId)
+
     if (!res.locals.user.name) {
       trackEvent('PiCAddCaseCommentNoName', res.locals.user)
     }

--- a/server/routes/handlers/getAddHearingNoteRequestHandler.js
+++ b/server/routes/handlers/getAddHearingNoteRequestHandler.js
@@ -13,6 +13,10 @@ const getAddHearingNoteHandler = caseService => async (req, res) => {
       res.locals.user.name,
       defendantId
     )
+
+    // Delete any draft so a late-arriving auto-save doesn't re-populate the textarea
+    await caseService.deleteHearingNoteDraft(targetHearingId, defendantId)
+
     if (!res.locals.user.name) {
       trackEvent('PiCAddHearingNoteNoName', res.locals.user)
     }

--- a/server/routes/handlers/index.js
+++ b/server/routes/handlers/index.js
@@ -36,13 +36,13 @@ const postDefendantMatchRouteHandler = require('./matchRecords/defendantMatchRou
 
 const outcomesRouter = require('./outcomes')
 
-const addCaseCommentRequestHandler = require('./getAddCommentRequestHandler')({ addCaseComment })
+const addCaseCommentRequestHandler = require('./getAddCommentRequestHandler')({ addCaseComment, deleteCaseCommentDraft })
 
 const deleteCaseCommentConfirmationHandler = require('./getDeleteCaseCommentConfirmationHandler')(getCaseAndTemplateValues)
 
 const deleteCaseCommentHandler = require('./getDeleteCaseCommentHandler')({ deleteCaseComment })
 
-const addHearingNoteRequestHandler = require('./getAddHearingNoteRequestHandler')({ addHearingNote })
+const addHearingNoteRequestHandler = require('./getAddHearingNoteRequestHandler')({ addHearingNote, deleteHearingNoteDraft })
 
 const deleteHearingNoteConfirmationHandler = require('./getDeleteHearingNoteConfirmationHandler')(getCaseAndTemplateValues)
 

--- a/server/views/components/hearing-notes/template.njk
+++ b/server/views/components/hearing-notes/template.njk
@@ -74,7 +74,7 @@
         {% if params.enableHearingNotes %}
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell govuk-!-padding-top-3 govuk-!-padding-bottom-2">
-                    <form id="save-notes-{{ params.hearing.hearingId }}" action="summary/notes" method="post">
+                    <form id="save-notes-{{ params.hearing.hearingId }}" class="hearing-note-form" action="summary/notes" method="post">
 
                         <details {{ 'open' if draftNote | length }} class="govuk-details govuk-!-margin-bottom-0"
                                                                     data-module="govuk-details">


### PR DESCRIPTION
Summary generated by GitHub Copilot:

**Bug:** When saving a comment or hearing note, the auto-save timer could still be running in the background. If it fired after the save, it would write a new draft which would then re-populate the text box on the next page load.

**Fix:** Two-layered approach:
- Client-side: replaced the auto-save logic with a `createAutoSave` factory that exposes a `cancel()` method. When either form is submitted, `cancel()` is called to clear the pending timer and abort any in-flight XHR request.
- Server-side: after saving a comment or note, the draft is immediately deleted. This covers the case where an auto-save request is already in-flight at the point of submission and can't be cancelled client-side.